### PR TITLE
Connection Details dropdown, opt-in SSID/BSSID, live stats, rate units

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "worktree": { "bgIsolation": "none" }
+}

--- a/QuickNetStats.xcodeproj/project.pbxproj
+++ b/QuickNetStats.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -395,6 +395,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "QuickNetStats never collects or stores your location. macOS requires Location Services permission to read the Wi-Fi network name (SSID) and access point address (BSSID).";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -437,7 +438,7 @@
 				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
 				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = YES;
 				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
 				ENABLE_RESOURCE_ACCESS_USB = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
@@ -446,6 +447,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "QuickNetStats never collects or stores your location. macOS requires Location Services permission to read the Wi-Fi network name (SSID) and access point address (BSSID).";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/QuickNetStats.xcodeproj/project.pbxproj
+++ b/QuickNetStats.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.federicoimberti.quicknetstats.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -451,7 +451,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.2.1;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.federicoimberti.quicknetstats;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/QuickNetStats/Managers/ConnectionDetailsManager.swift
+++ b/QuickNetStats/Managers/ConnectionDetailsManager.swift
@@ -1,0 +1,239 @@
+//
+//  ConnectionDetailsManager.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+import Combine
+
+/// Assembles advanced connection details from the three readers and drives the
+/// optional live-metrics polling loop. Main-actor isolated (project default);
+/// never throws to the UI — any value a reader can't determine is simply absent.
+class ConnectionDetailsManager: ObservableObject {
+
+    // MARK: - Published State
+
+    /// The last assembled static snapshot; nil until the first `fetchDetails()`.
+    @Published private(set) var details: ConnectionDetails?
+
+    /// The latest live sample; nil unless live polling is active.
+    @Published private(set) var liveStats: LiveConnectionStats?
+
+    /// Whether the live polling loop is running.
+    @Published private(set) var isLive = false
+
+    // MARK: - Dependencies
+
+    private let systemConfig: SystemConfigReading
+    private let interfaceReader: InterfaceReading
+    private let wifiReader: WifiReading
+    private let session: URLSession
+    private let pollInterval: TimeInterval
+
+    /// The running poll loop, if any.
+    private var liveTask: Task<Void, Never>?
+
+    /// A byte-counter sample taken at a point in time, used to compute deltas.
+    private struct ByteSample {
+        let rx: UInt64
+        let tx: UInt64
+        let at: Date
+    }
+
+    /// The previous throughput sample, used to compute per-second deltas.
+    private var previousSample: ByteSample?
+
+    // MARK: - Initializer
+
+    init(
+        systemConfig: SystemConfigReading = SystemConfigReader(),
+        interfaceReader: InterfaceReading = InterfaceReader(),
+        wifiReader: WifiReading = WifiReader(),
+        session: URLSession = .reachabilitySession,
+        pollInterval: TimeInterval = 1.0
+    ) {
+        self.systemConfig = systemConfig
+        self.interfaceReader = interfaceReader
+        self.wifiReader = wifiReader
+        self.session = session
+        self.pollInterval = pollInterval
+    }
+
+    // MARK: - Fetch
+
+    /// Reads all three readers plus the public IPv6 lookup and publishes one
+    /// assembled `ConnectionDetails`. Called on first expand and by `refresh()`.
+    func fetchDetails() async {
+        let scSnapshot = systemConfig.snapshot()
+
+        // Fetch the public IPv6 concurrently with the local (synchronous) reads.
+        async let publicIPv6 = fetchPublicIPv6()
+
+        var interfaceSnapshot = InterfaceSnapshot()
+        var wifiSnapshot: WifiSnapshot?
+        if let bsdName = scSnapshot.primaryInterface {
+            interfaceSnapshot = interfaceReader.snapshot(for: bsdName)
+            wifiSnapshot = wifiReader.snapshot(for: bsdName)
+        }
+
+        let resolvedPublicIPv6 = await publicIPv6
+
+        // A cancelled fetch (popover closed mid-expand) must not publish a
+        // half-fetched snapshot: `details != nil` would block the retry on the
+        // next expand and silently lose the public IPv6 row.
+        guard !Task.isCancelled else { return }
+
+        details = ConnectionDetails(
+            interface: .init(
+                bsdName: scSnapshot.primaryInterface,
+                displayName: scSnapshot.primaryInterfaceDisplayName,
+                macAddress: interfaceSnapshot.macAddress,
+                mtu: interfaceSnapshot.mtu,
+                linkSpeedMbps: interfaceSnapshot.linkSpeedMbps
+            ),
+            addressing: .init(
+                ipv6Address: interfaceSnapshot.ipv6Address,
+                publicIPv6: resolvedPublicIPv6,
+                subnetMask: scSnapshot.subnetMask,
+                routerAddress: scSnapshot.routerAddress,
+                hostname: scSnapshot.hostname
+            ),
+            dnsDhcp: .init(
+                dnsServers: scSnapshot.dnsServers,
+                searchDomains: scSnapshot.searchDomains,
+                dhcpLeaseExpiry: scSnapshot.dhcpLeaseExpiry
+            ),
+            wifi: wifiSnapshot.map(Self.wifiGroup)
+        )
+    }
+
+    /// Re-fetches the static details, but only once the dropdown has been opened
+    /// at least once (`details != nil`). Wired into the existing refresh button.
+    func refresh() async {
+        guard details != nil else { return }
+        await fetchDetails()
+    }
+
+    // MARK: - Live polling
+
+    /// Starts polling live metrics every `pollInterval`. The first tick publishes
+    /// RF values with nil throughput (no prior counter sample yet); subsequent
+    /// ticks add throughput. No-op if already live.
+    func startLive() {
+        guard !isLive else { return }
+        isLive = true
+        previousSample = nil
+        liveTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.tick()
+                try? await Task.sleep(for: .seconds(self.pollInterval))
+            }
+        }
+    }
+
+    /// Stops polling, cancels the loop, and clears live state.
+    func stopLive() {
+        liveTask?.cancel()
+        liveTask = nil
+        isLive = false
+        liveStats = nil
+        previousSample = nil
+    }
+
+    /// Reads one live sample: byte counters (→ throughput vs the previous tick)
+    /// and the Wi-Fi RF snapshot. Guards on a known primary interface.
+    private func tick() {
+        guard let bsdName = details?.interface.bsdName else { return }
+
+        let interfaceSnapshot = interfaceReader.snapshot(for: bsdName)
+        let wifiSnapshot = wifiReader.snapshot(for: bsdName)
+
+        let now = Date()
+        var download: Double?
+        var upload: Double?
+        if let previous = previousSample,
+           let rx = interfaceSnapshot.rxBytes,
+           let tx = interfaceSnapshot.txBytes {
+            let elapsed = now.timeIntervalSince(previous.at)
+            download = Self.bytesPerSecond(previous: previous.rx, current: rx, elapsed: elapsed)
+            upload = Self.bytesPerSecond(previous: previous.tx, current: tx, elapsed: elapsed)
+        }
+        if let rx = interfaceSnapshot.rxBytes, let tx = interfaceSnapshot.txBytes {
+            previousSample = ByteSample(rx: rx, tx: tx, at: now)
+        }
+
+        liveStats = LiveConnectionStats(
+            downloadBytesPerSec: download,
+            uploadBytesPerSec: upload,
+            rssiDBm: wifiSnapshot?.rssiDBm,
+            noiseDBm: wifiSnapshot?.noiseDBm,
+            txRateMbps: wifiSnapshot?.txRateMbps
+        )
+    }
+
+    /// Computes a per-second byte rate from two counter samples. Returns nil on a
+    /// non-positive elapsed time or a counter reset (current < previous).
+    static func bytesPerSecond(previous: UInt64, current: UInt64, elapsed: TimeInterval) -> Double? {
+        guard elapsed > 0, current >= previous else { return nil }
+        return Double(current - previous) / elapsed
+    }
+
+    // MARK: - Helpers
+
+    /// Maps a `WifiSnapshot` to the model's Wi-Fi group.
+    private static func wifiGroup(_ snapshot: WifiSnapshot) -> ConnectionDetails.Wifi {
+        ConnectionDetails.Wifi(
+            channelNumber: snapshot.channelNumber,
+            band: snapshot.band,
+            channelWidthMHz: snapshot.channelWidthMHz,
+            phyMode: snapshot.phyMode,
+            security: snapshot.security,
+            countryCode: snapshot.countryCode
+        )
+    }
+
+    /// Fetches the device's public IPv6 via `api6.ipify.org`. Returns nil on any
+    /// failure, a non-2xx status, or a body that isn't an IPv6 literal (no colon)
+    /// — common when the network has no IPv6 connectivity.
+    private func fetchPublicIPv6() async -> String? {
+        let url = URL(string: "https://api6.ipify.org")!
+        do {
+            let (data, response) = try await session.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode) else {
+                return nil
+            }
+            guard let body = String(data: data, encoding: .utf8), body.contains(":") else {
+                return nil
+            }
+            return body
+        } catch {
+            return nil
+        }
+    }
+
+    deinit {
+        liveTask?.cancel()
+    }
+}
+
+#if DEBUG
+extension ConnectionDetailsManager {
+    /// Builds a manager pre-populated with static state for SwiftUI previews.
+    /// No fetch is performed and the real readers are never consulted.
+    static func preview(
+        details: ConnectionDetails?,
+        isLive: Bool = false,
+        liveStats: LiveConnectionStats? = nil
+    ) -> ConnectionDetailsManager {
+        let manager = ConnectionDetailsManager()
+        manager.details = details
+        manager.isLive = isLive
+        manager.liveStats = liveStats
+        return manager
+    }
+}
+#endif

--- a/QuickNetStats/Managers/ConnectionDetailsManager.swift
+++ b/QuickNetStats/Managers/ConnectionDetailsManager.swift
@@ -36,6 +36,15 @@ class ConnectionDetailsManager: ObservableObject {
     /// The running poll loop, if any.
     private var liveTask: Task<Void, Never>?
 
+    /// The in-flight refetch scheduled by a connection change, cancelled and
+    /// replaced if another change arrives before it finishes so a superseded
+    /// (cancelled) fetch never publishes stale data.
+    private var changeTask: Task<Void, Never>?
+
+    /// Retains the connection-change subscription so `observeConnectionChanges`
+    /// only ever subscribes once.
+    private var connectionChangeCancellable: AnyCancellable?
+
     /// A full counter sample taken at a point in time, used to compute per-second
     /// deltas for throughput, packet, error, and drop rates.
     private struct CounterSample {
@@ -155,6 +164,28 @@ class ConnectionDetailsManager: ObservableObject {
     func refresh() async {
         guard details != nil else { return }
         await fetchDetails()
+    }
+
+    // MARK: - Connection change
+
+    /// Invalidates the cached details when the active connection changes so an
+    /// open dropdown stops showing the previous interface's fields. 
+    func connectionChanged() {
+        guard details != nil else { return }
+        details = nil
+        previousSample = nil
+        changeTask?.cancel()
+        changeTask = Task { await fetchDetails() }
+    }
+
+    /// Subscribes to network-stats changes so `connectionChanged()` fires on
+    /// every connection switch (Wi-Fi → Ethernet, Wi-Fi A → Wi-Fi B). Idempotent:
+    /// repeated calls (e.g. on every popover appearance) subscribe only once.
+    func observeConnectionChanges(_ publisher: AnyPublisher<NetworkStats, Never>) {
+        guard connectionChangeCancellable == nil else { return }
+        connectionChangeCancellable = publisher.sink { [weak self] _ in
+            self?.connectionChanged()
+        }
     }
 
     // MARK: - Live polling
@@ -282,6 +313,7 @@ class ConnectionDetailsManager: ObservableObject {
 
     deinit {
         liveTask?.cancel()
+        changeTask?.cancel()
     }
 }
 

--- a/QuickNetStats/Managers/ConnectionDetailsManager.swift
+++ b/QuickNetStats/Managers/ConnectionDetailsManager.swift
@@ -102,6 +102,7 @@ class ConnectionDetailsManager: ObservableObject {
                 bsdName: scSnapshot.primaryInterface,
                 displayName: scSnapshot.primaryInterfaceDisplayName,
                 macAddress: interfaceSnapshot.macAddress,
+                bssid: wifiSnapshot?.bssid,
                 mtu: interfaceSnapshot.mtu,
                 linkSpeedMbps: interfaceSnapshot.linkSpeedMbps,
                 mediaDescription: interfaceSnapshot.mediaDescription,

--- a/QuickNetStats/Managers/ConnectionDetailsManager.swift
+++ b/QuickNetStats/Managers/ConnectionDetailsManager.swift
@@ -29,21 +29,27 @@ class ConnectionDetailsManager: ObservableObject {
     private let systemConfig: SystemConfigReading
     private let interfaceReader: InterfaceReading
     private let wifiReader: WifiReading
+    private let pathReader: PathReading
     private let session: URLSession
     private let pollInterval: TimeInterval
 
     /// The running poll loop, if any.
     private var liveTask: Task<Void, Never>?
 
-    /// A byte-counter sample taken at a point in time, used to compute deltas.
-    private struct ByteSample {
-        let rx: UInt64
-        let tx: UInt64
+    /// A full counter sample taken at a point in time, used to compute per-second
+    /// deltas for throughput, packet, error, and drop rates.
+    private struct CounterSample {
+        let rxBytes: UInt64
+        let txBytes: UInt64
+        let rxPackets: UInt64
+        let txPackets: UInt64
+        let errors: UInt64      // combined in + out
+        let drops: UInt64
         let at: Date
     }
 
-    /// The previous throughput sample, used to compute per-second deltas.
-    private var previousSample: ByteSample?
+    /// The previous counter sample, used to compute per-second deltas.
+    private var previousSample: CounterSample?
 
     // MARK: - Initializer
 
@@ -51,25 +57,30 @@ class ConnectionDetailsManager: ObservableObject {
         systemConfig: SystemConfigReading = SystemConfigReader(),
         interfaceReader: InterfaceReading = InterfaceReader(),
         wifiReader: WifiReading = WifiReader(),
+        pathReader: PathReading = PathReader(),
         session: URLSession = .reachabilitySession,
         pollInterval: TimeInterval = 1.0
     ) {
         self.systemConfig = systemConfig
         self.interfaceReader = interfaceReader
         self.wifiReader = wifiReader
+        self.pathReader = pathReader
         self.session = session
         self.pollInterval = pollInterval
     }
 
     // MARK: - Fetch
 
-    /// Reads all three readers plus the public IPv6 lookup and publishes one
-    /// assembled `ConnectionDetails`. Called on first expand and by `refresh()`.
+    /// Reads all four readers (system config, interface, Wi-Fi, path) plus the
+    /// public IPv6 lookup and publishes one assembled `ConnectionDetails`. Called on
+    /// first expand and by `refresh()`.
     func fetchDetails() async {
         let scSnapshot = systemConfig.snapshot()
 
-        // Fetch the public IPv6 concurrently with the local (synchronous) reads.
+        // Fetch the public IPv6 and the one-shot NWPath concurrently with the
+        // local (synchronous) reads.
         async let publicIPv6 = fetchPublicIPv6()
+        async let pathSnapshot = pathReader.snapshot(excluding: scSnapshot.primaryInterface)
 
         var interfaceSnapshot = InterfaceSnapshot()
         var wifiSnapshot: WifiSnapshot?
@@ -79,6 +90,7 @@ class ConnectionDetailsManager: ObservableObject {
         }
 
         let resolvedPublicIPv6 = await publicIPv6
+        let resolvedPath = await pathSnapshot
 
         // A cancelled fetch (popover closed mid-expand) must not publish a
         // half-fetched snapshot: `details != nil` would block the retry on the
@@ -91,22 +103,50 @@ class ConnectionDetailsManager: ObservableObject {
                 displayName: scSnapshot.primaryInterfaceDisplayName,
                 macAddress: interfaceSnapshot.macAddress,
                 mtu: interfaceSnapshot.mtu,
-                linkSpeedMbps: interfaceSnapshot.linkSpeedMbps
+                linkSpeedMbps: interfaceSnapshot.linkSpeedMbps,
+                mediaDescription: interfaceSnapshot.mediaDescription,
+                supports: Self.supportsText(resolvedPath),
+                otherInterfaces: resolvedPath.otherInterfaces
             ),
             addressing: .init(
                 ipv6Address: interfaceSnapshot.ipv6Address,
                 publicIPv6: resolvedPublicIPv6,
                 subnetMask: scSnapshot.subnetMask,
                 routerAddress: scSnapshot.routerAddress,
-                hostname: scSnapshot.hostname
+                hostname: scSnapshot.hostname,
+                ipv6Router: scSnapshot.ipv6Router,
+                broadcastAddress: interfaceSnapshot.broadcastAddress,
+                ipv4ConfigMethod: scSnapshot.ipv4ConfigMethod,
+                computerName: scSnapshot.computerName
             ),
             dnsDhcp: .init(
                 dnsServers: scSnapshot.dnsServers,
                 searchDomains: scSnapshot.searchDomains,
+                dhcpServer: scSnapshot.dhcpServer,
+                dhcpLeaseStart: scSnapshot.dhcpLeaseStart,
                 dhcpLeaseExpiry: scSnapshot.dhcpLeaseExpiry
+            ),
+            proxy: .init(
+                httpProxy: scSnapshot.proxies.http,
+                httpsProxy: scSnapshot.proxies.https,
+                socksProxy: scSnapshot.proxies.socks
             ),
             wifi: wifiSnapshot.map(Self.wifiGroup)
         )
+    }
+
+    /// Composes the NWPath capability list ("IPv4 · IPv6 · DNS") from a path
+    /// snapshot: only flags that are `true` are listed; all-false yields "None";
+    /// all-nil (an empty/timed-out snapshot) yields nil so the row is omitted.
+    static func supportsText(_ path: PathSnapshot) -> String? {
+        let flags: [(Bool?, String)] = [
+            (path.supportsIPv4, "IPv4"),
+            (path.supportsIPv6, "IPv6"),
+            (path.supportsDNS, "DNS")
+        ]
+        guard flags.contains(where: { $0.0 != nil }) else { return nil }
+        let enabled = flags.compactMap { flag, label in flag == true ? label : nil }
+        return enabled.isEmpty ? "None" : enabled.joined(separator: " · ")
     }
 
     /// Re-fetches the static details, but only once the dropdown has been opened
@@ -143,8 +183,9 @@ class ConnectionDetailsManager: ObservableObject {
         previousSample = nil
     }
 
-    /// Reads one live sample: byte counters (→ throughput vs the previous tick)
-    /// and the Wi-Fi RF snapshot. Guards on a known primary interface.
+    /// Reads one live sample: byte/packet/error/drop counters (→ per-second rates
+    /// vs the previous tick) and the Wi-Fi RF snapshot. Guards on a known primary
+    /// interface. Rates stay nil until a second sample exists.
     private func tick() {
         guard let bsdName = details?.interface.bsdName else { return }
 
@@ -152,29 +193,50 @@ class ConnectionDetailsManager: ObservableObject {
         let wifiSnapshot = wifiReader.snapshot(for: bsdName)
 
         let now = Date()
-        var download: Double?
-        var upload: Double?
-        if let previous = previousSample,
-           let rx = interfaceSnapshot.rxBytes,
-           let tx = interfaceSnapshot.txBytes {
+        let current = Self.counterSample(from: interfaceSnapshot, at: now)
+
+        var download, upload, downloadPackets, uploadPackets, errors, drops: Double?
+        if let previous = previousSample, let current {
             let elapsed = now.timeIntervalSince(previous.at)
-            download = Self.bytesPerSecond(previous: previous.rx, current: rx, elapsed: elapsed)
-            upload = Self.bytesPerSecond(previous: previous.tx, current: tx, elapsed: elapsed)
+            download = Self.bytesPerSecond(previous: previous.rxBytes, current: current.rxBytes, elapsed: elapsed)
+            upload = Self.bytesPerSecond(previous: previous.txBytes, current: current.txBytes, elapsed: elapsed)
+            downloadPackets = Self.bytesPerSecond(previous: previous.rxPackets, current: current.rxPackets, elapsed: elapsed)
+            uploadPackets = Self.bytesPerSecond(previous: previous.txPackets, current: current.txPackets, elapsed: elapsed)
+            errors = Self.bytesPerSecond(previous: previous.errors, current: current.errors, elapsed: elapsed)
+            drops = Self.bytesPerSecond(previous: previous.drops, current: current.drops, elapsed: elapsed)
         }
-        if let rx = interfaceSnapshot.rxBytes, let tx = interfaceSnapshot.txBytes {
-            previousSample = ByteSample(rx: rx, tx: tx, at: now)
-        }
+        if let current { previousSample = current }
 
         liveStats = LiveConnectionStats(
             downloadBytesPerSec: download,
             uploadBytesPerSec: upload,
+            downloadPacketsPerSec: downloadPackets,
+            uploadPacketsPerSec: uploadPackets,
+            errorsPerSec: errors,
+            dropsPerSec: drops,
             rssiDBm: wifiSnapshot?.rssiDBm,
             noiseDBm: wifiSnapshot?.noiseDBm,
             txRateMbps: wifiSnapshot?.txRateMbps
         )
     }
 
-    /// Computes a per-second byte rate from two counter samples. Returns nil on a
+    /// Builds a `CounterSample` from an interface snapshot, or nil if any counter
+    /// is missing (all come from the same `if_data64` read, so it is all-or-nothing).
+    private static func counterSample(from snapshot: InterfaceSnapshot, at date: Date) -> CounterSample? {
+        guard let rxBytes = snapshot.rxBytes, let txBytes = snapshot.txBytes,
+              let rxPackets = snapshot.rxPackets, let txPackets = snapshot.txPackets,
+              let inErrors = snapshot.inErrors, let outErrors = snapshot.outErrors,
+              let drops = snapshot.drops else {
+            return nil
+        }
+        return CounterSample(
+            rxBytes: rxBytes, txBytes: txBytes,
+            rxPackets: rxPackets, txPackets: txPackets,
+            errors: inErrors &+ outErrors, drops: drops, at: date
+        )
+    }
+
+    /// Computes a per-second rate from two counter samples. Returns nil on a
     /// non-positive elapsed time or a counter reset (current < previous).
     static func bytesPerSecond(previous: UInt64, current: UInt64, elapsed: TimeInterval) -> Double? {
         guard elapsed > 0, current >= previous else { return nil }
@@ -190,6 +252,8 @@ class ConnectionDetailsManager: ObservableObject {
             band: snapshot.band,
             channelWidthMHz: snapshot.channelWidthMHz,
             phyMode: snapshot.phyMode,
+            mode: snapshot.interfaceMode,
+            txPowerMw: snapshot.txPowerMw,
             security: snapshot.security,
             countryCode: snapshot.countryCode
         )

--- a/QuickNetStats/Managers/ConnectionDetailsManager.swift
+++ b/QuickNetStats/Managers/ConnectionDetailsManager.swift
@@ -220,7 +220,8 @@ class ConnectionDetailsManager: ObservableObject {
     }
 }
 
-#if DEBUG
+// Not #if DEBUG-guarded: #Preview bodies compile in Release too, and the
+// existing mock convention (NetworkStats.mock*) ships unguarded as well.
 extension ConnectionDetailsManager {
     /// Builds a manager pre-populated with static state for SwiftUI previews.
     /// No fetch is performed and the real readers are never consulted.
@@ -236,4 +237,3 @@ extension ConnectionDetailsManager {
         return manager
     }
 }
-#endif

--- a/QuickNetStats/Managers/InterfaceReader.swift
+++ b/QuickNetStats/Managers/InterfaceReader.swift
@@ -12,9 +12,16 @@ struct InterfaceSnapshot: Equatable {
     var macAddress: String?      // "aa:bb:cc:dd:ee:ff"
     var mtu: Int?
     var ipv6Address: String?
+    var broadcastAddress: String?
     var linkSpeedMbps: Double?
+    var mediaDescription: String?   // "1000baseT full-duplex"; nil off Ethernet
     var rxBytes: UInt64?
     var txBytes: UInt64?
+    var rxPackets: UInt64?
+    var txPackets: UInt64?
+    var inErrors: UInt64?
+    var outErrors: UInt64?
+    var drops: UInt64?
 }
 
 /// A seam over `getifaddrs`/`sysctl` reads so the manager stays testable.
@@ -44,8 +51,16 @@ struct InterfaceReader: InterfaceReading {
                 switch Int32(addr.pointee.sa_family) {
                 case AF_LINK:
                     Self.readLinkLayer(addr: addr, data: interface.ifa_data, into: &result)
+                case AF_INET:
+                    // On Darwin ifa_dstaddr aliases the broadcast address for
+                    // IFF_BROADCAST interfaces; ignore it otherwise (e.g. p2p links).
+                    if (interface.ifa_flags & UInt32(IFF_BROADCAST)) != 0,
+                       let dst = interface.ifa_dstaddr,
+                       let broadcast = Self.numericHost(from: dst) {
+                        result.broadcastAddress = broadcast
+                    }
                 case AF_INET6:
-                    if let ipv6 = Self.ipv6String(from: addr) {
+                    if let ipv6 = Self.numericHost(from: addr) {
                         ipv6Candidates.append(ipv6)
                     }
                 default:
@@ -55,7 +70,16 @@ struct InterfaceReader: InterfaceReading {
         }
 
         result.ipv6Address = Self.preferredIPv6(from: ipv6Candidates)
-        (result.rxBytes, result.txBytes) = Self.byteCounters(for: bsdName)
+        result.mediaDescription = Self.mediaDescription(for: bsdName)
+        if let counters = Self.counters(for: bsdName) {
+            result.rxBytes = counters.rxBytes
+            result.txBytes = counters.txBytes
+            result.rxPackets = counters.rxPackets
+            result.txPackets = counters.txPackets
+            result.inErrors = counters.inErrors
+            result.outErrors = counters.outErrors
+            result.drops = counters.drops
+        }
         return result
     }
 
@@ -112,8 +136,9 @@ struct InterfaceReader: InterfaceReading {
         }
     }
 
-    /// Formats an `AF_INET6` address as a numeric string, stripping any `%scope`.
-    private static func ipv6String(from addr: UnsafeMutablePointer<sockaddr>) -> String? {
+    /// Formats a `sockaddr` (IPv4 or IPv6) as a numeric string, stripping any
+    /// `%scope` suffix. Works for both `AF_INET` (broadcast) and `AF_INET6` addresses.
+    private static func numericHost(from addr: UnsafeMutablePointer<sockaddr>) -> String? {
         var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
         let status = getnameinfo(
             addr, socklen_t(addr.pointee.sa_len),
@@ -128,29 +153,100 @@ struct InterfaceReader: InterfaceReading {
         return address
     }
 
-    // MARK: - Byte counters
+    // MARK: - Media type
 
-    /// Reads 64-bit rx/tx byte counters via `sysctl NET_RT_IFLIST2` (avoids the
-    /// 32-bit rollover of the `getifaddrs` counters). Returns `(nil, nil)` if the
+    /// Reads the active Ethernet media description for `bsdName` via the
+    /// `SIOCGIFMEDIA` ioctl on a throwaway datagram socket. Returns nil for
+    /// non-Ethernet interfaces, unmapped subtypes, or any ioctl failure — never
+    /// surfaces an error. Wi-Fi links report subtypes outside our table and so
+    /// naturally degrade to nil.
+    private static func mediaDescription(for bsdName: String) -> String? {
+        let sock = socket(AF_INET, SOCK_DGRAM, 0)
+        guard sock >= 0 else { return nil }
+        defer { close(sock) }
+
+        var request = ifmediareq()
+        let copied = bsdName.withCString { source -> Bool in
+            withUnsafeMutablePointer(to: &request.ifm_name) { namePtr in
+                namePtr.withMemoryRebound(to: CChar.self, capacity: Int(IFNAMSIZ)) { dest in
+                    strlcpy(dest, source, Int(IFNAMSIZ)) < Int(IFNAMSIZ)
+                }
+            }
+        }
+        guard copied else { return nil }
+
+        let status = withUnsafeMutablePointer(to: &request) { ptr in
+            ioctl(sock, Self.siocgifmedia, ptr)
+        }
+        guard status >= 0 else { return nil }
+        return mediaDescription(active: request.ifm_active)
+    }
+
+    /// `SIOCGIFMEDIA` request number computed per `<sys/ioccom.h>` `_IOWR('i', 56,
+    /// ifmediareq)`; the macro isn't imported, and using `MemoryLayout.stride` keeps
+    /// the encoded size in step with the kernel's `#pragma pack(4)` layout.
+    private static var siocgifmedia: UInt {
+        let inOut = UInt(IOC_IN) | UInt(IOC_OUT)
+        let size = UInt(MemoryLayout<ifmediareq>.stride & Int(IOCPARM_MASK))
+        return inOut | (size << 16) | (UInt(UInt8(ascii: "i")) << 8) | 56
+    }
+
+    /// Ethernet subtype code → display name for the subtypes we surface.
+    private static let ethernetSubtypeNames: [Int: String] = [
+        Int(IFM_10_T): "10baseT",
+        Int(IFM_100_TX): "100baseTX",
+        Int(IFM_1000_T): "1000baseT",
+        Int(IFM_2500_T): "2500baseT",
+        Int(IFM_5000_T): "5000baseT",
+        Int(IFM_10G_T): "10GbaseT"
+    ]
+
+    /// Maps an `ifmediareq.ifm_active` bitfield to an Ethernet media description
+    /// ("1000baseT full-duplex"); nil for non-Ethernet media or an unmapped subtype.
+    static func mediaDescription(active: Int32) -> String? {
+        let value = Int(active)
+        guard value & Int(IFM_NMASK) == Int(IFM_ETHER) else { return nil }
+        let subtype = value & (Int(IFM_TMASK_COMPAT) | Int(IFM_TMASK_EXT))
+        guard let name = ethernetSubtypeNames[subtype] else { return nil }
+        if value & Int(IFM_FDX) != 0 { return "\(name) full-duplex" }
+        if value & Int(IFM_HDX) != 0 { return "\(name) half-duplex" }
+        return name
+    }
+
+    // MARK: - Counters
+
+    /// The full 64-bit counter set decoded from one `if_data64` record.
+    private struct RawCounters {
+        var rxBytes: UInt64
+        var txBytes: UInt64
+        var rxPackets: UInt64
+        var txPackets: UInt64
+        var inErrors: UInt64
+        var outErrors: UInt64
+        var drops: UInt64
+    }
+
+    /// Reads 64-bit byte/packet/error/drop counters via `sysctl NET_RT_IFLIST2`
+    /// (avoids the 32-bit rollover of the `getifaddrs` counters). Returns nil if the
     /// interface is unknown or the query fails.
-    private static func byteCounters(for bsdName: String) -> (UInt64?, UInt64?) {
+    private static func counters(for bsdName: String) -> RawCounters? {
         let index = if_nametoindex(bsdName)
-        guard index != 0 else { return (nil, nil) }
+        guard index != 0 else { return nil }
 
         var mib: [Int32] = [CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0]
         var length = 0
         guard sysctl(&mib, u_int(mib.count), nil, &length, nil, 0) == 0, length > 0 else {
-            return (nil, nil)
+            return nil
         }
 
         var buffer = [UInt8](repeating: 0, count: length)
         let success = buffer.withUnsafeMutableBytes { raw in
             sysctl(&mib, u_int(mib.count), raw.baseAddress, &length, nil, 0) == 0
         }
-        guard success else { return (nil, nil) }
+        guard success else { return nil }
 
-        return buffer.withUnsafeBytes { raw -> (UInt64?, UInt64?) in
-            guard let base = raw.baseAddress else { return (nil, nil) }
+        return buffer.withUnsafeBytes { raw -> RawCounters? in
+            guard let base = raw.baseAddress else { return nil }
             var offset = 0
             while offset + MemoryLayout<if_msghdr>.size <= length {
                 let header = base.advanced(by: offset).loadUnaligned(as: if_msghdr.self)
@@ -162,12 +258,21 @@ struct InterfaceReader: InterfaceReading {
                    messageLength >= MemoryLayout<if_msghdr2>.size {
                     let header2 = base.advanced(by: offset).loadUnaligned(as: if_msghdr2.self)
                     if UInt32(header2.ifm_index) == index {
-                        return (header2.ifm_data.ifi_ibytes, header2.ifm_data.ifi_obytes)
+                        let data = header2.ifm_data
+                        return RawCounters(
+                            rxBytes: data.ifi_ibytes,
+                            txBytes: data.ifi_obytes,
+                            rxPackets: data.ifi_ipackets,
+                            txPackets: data.ifi_opackets,
+                            inErrors: data.ifi_ierrors,
+                            outErrors: data.ifi_oerrors,
+                            drops: data.ifi_iqdrops
+                        )
                     }
                 }
                 offset += messageLength
             }
-            return (nil, nil)
+            return nil
         }
     }
 }

--- a/QuickNetStats/Managers/InterfaceReader.swift
+++ b/QuickNetStats/Managers/InterfaceReader.swift
@@ -1,0 +1,173 @@
+//
+//  InterfaceReader.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+
+/// A read-only snapshot of BSD-layer facts for a single interface.
+struct InterfaceSnapshot: Equatable {
+    var macAddress: String?      // "aa:bb:cc:dd:ee:ff"
+    var mtu: Int?
+    var ipv6Address: String?
+    var linkSpeedMbps: Double?
+    var rxBytes: UInt64?
+    var txBytes: UInt64?
+}
+
+/// A seam over `getifaddrs`/`sysctl` reads so the manager stays testable.
+protocol InterfaceReading {
+    func snapshot(for bsdName: String) -> InterfaceSnapshot
+}
+
+/// Reads MAC, MTU, local IPv6, link speed, and 64-bit byte counters for a BSD
+/// interface via `getifaddrs` (link + IPv6 facts) and `sysctl NET_RT_IFLIST2`
+/// (rollover-safe counters). All reads are optional-safe.
+struct InterfaceReader: InterfaceReading {
+
+    /// Builds a snapshot for the given BSD interface name (e.g. "en0").
+    func snapshot(for bsdName: String) -> InterfaceSnapshot {
+        var result = InterfaceSnapshot()
+        var ipv6Candidates: [String] = []
+
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        if getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr {
+            defer { freeifaddrs(ifaddr) }
+
+            for ptr in sequence(first: firstAddr, next: { $0.pointee.ifa_next }) {
+                let interface = ptr.pointee
+                guard String(cString: interface.ifa_name) == bsdName,
+                      let addr = interface.ifa_addr else { continue }
+
+                switch Int32(addr.pointee.sa_family) {
+                case AF_LINK:
+                    Self.readLinkLayer(addr: addr, data: interface.ifa_data, into: &result)
+                case AF_INET6:
+                    if let ipv6 = Self.ipv6String(from: addr) {
+                        ipv6Candidates.append(ipv6)
+                    }
+                default:
+                    break
+                }
+            }
+        }
+
+        result.ipv6Address = Self.preferredIPv6(from: ipv6Candidates)
+        (result.rxBytes, result.txBytes) = Self.byteCounters(for: bsdName)
+        return result
+    }
+
+    // MARK: - IPv6 preference
+
+    /// Picks the best local IPv6: global unicast first, then ULA (`fc00::/7`),
+    /// never link-local (`fe80::/10`). Case-insensitive; deterministic first match.
+    static func preferredIPv6(from candidates: [String]) -> String? {
+        // Drop link-local; only fe80:: is ever assigned in practice.
+        // ponytail: fe80 prefix check; widen to the full fe80::/10 range only if a
+        // real fe9x/fexx link-local address ever surfaces.
+        let routable = candidates.filter { !$0.lowercased().hasPrefix("fe80") }
+        if let global = routable.first(where: {
+            let lower = $0.lowercased()
+            return !lower.hasPrefix("fc") && !lower.hasPrefix("fd")
+        }) {
+            return global
+        }
+        return routable.first
+    }
+
+    // MARK: - getifaddrs decoding
+
+    /// Decodes MAC address, MTU, and link speed from an `AF_LINK` entry.
+    private static func readLinkLayer(
+        addr: UnsafeMutablePointer<sockaddr>,
+        data: UnsafeMutableRawPointer?,
+        into result: inout InterfaceSnapshot
+    ) {
+        addr.withMemoryRebound(to: sockaddr_dl.self, capacity: 1) { dlPtr in
+            let dl = dlPtr.pointee
+            guard dl.sdl_alen == 6,
+                  let dataOffset = MemoryLayout<sockaddr_dl>.offset(of: \.sdl_data),
+                  // The MAC bytes must lie inside the sdl_len-sized allocation.
+                  dataOffset + Int(dl.sdl_nlen) + 6 <= Int(dl.sdl_len) else { return }
+            // LLADDR(sdl) = sdl_data + sdl_nlen; read from the raw allocation so we
+            // don't rely on the 12-byte declared size of the sdl_data tuple.
+            let macStart = UnsafeRawPointer(dlPtr)
+                .advanced(by: dataOffset + Int(dl.sdl_nlen))
+                .assumingMemoryBound(to: UInt8.self)
+            result.macAddress = (0..<6)
+                .map { String(format: "%02x", macStart[$0]) }
+                .joined(separator: ":")
+        }
+
+        if let data {
+            data.withMemoryRebound(to: if_data.self, capacity: 1) { dataPtr in
+                result.mtu = Int(dataPtr.pointee.ifi_mtu)
+                let baudrate = dataPtr.pointee.ifi_baudrate
+                if baudrate > 0 {
+                    result.linkSpeedMbps = Double(baudrate) / 1_000_000
+                }
+            }
+        }
+    }
+
+    /// Formats an `AF_INET6` address as a numeric string, stripping any `%scope`.
+    private static func ipv6String(from addr: UnsafeMutablePointer<sockaddr>) -> String? {
+        var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+        let status = getnameinfo(
+            addr, socklen_t(addr.pointee.sa_len),
+            &host, socklen_t(host.count),
+            nil, 0, NI_NUMERICHOST
+        )
+        guard status == 0 else { return nil }
+        var address = String(cString: host)
+        if let scope = address.firstIndex(of: "%") {
+            address = String(address[..<scope])
+        }
+        return address
+    }
+
+    // MARK: - Byte counters
+
+    /// Reads 64-bit rx/tx byte counters via `sysctl NET_RT_IFLIST2` (avoids the
+    /// 32-bit rollover of the `getifaddrs` counters). Returns `(nil, nil)` if the
+    /// interface is unknown or the query fails.
+    private static func byteCounters(for bsdName: String) -> (UInt64?, UInt64?) {
+        let index = if_nametoindex(bsdName)
+        guard index != 0 else { return (nil, nil) }
+
+        var mib: [Int32] = [CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0]
+        var length = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &length, nil, 0) == 0, length > 0 else {
+            return (nil, nil)
+        }
+
+        var buffer = [UInt8](repeating: 0, count: length)
+        let success = buffer.withUnsafeMutableBytes { raw in
+            sysctl(&mib, u_int(mib.count), raw.baseAddress, &length, nil, 0) == 0
+        }
+        guard success else { return (nil, nil) }
+
+        return buffer.withUnsafeBytes { raw -> (UInt64?, UInt64?) in
+            guard let base = raw.baseAddress else { return (nil, nil) }
+            var offset = 0
+            while offset + MemoryLayout<if_msghdr>.size <= length {
+                let header = base.advanced(by: offset).loadUnaligned(as: if_msghdr.self)
+                let messageLength = Int(header.ifm_msglen)
+                guard messageLength > 0 else { break }
+
+                if header.ifm_type == RTM_IFINFO2,
+                   offset + MemoryLayout<if_msghdr2>.size <= length,
+                   messageLength >= MemoryLayout<if_msghdr2>.size {
+                    let header2 = base.advanced(by: offset).loadUnaligned(as: if_msghdr2.self)
+                    if UInt32(header2.ifm_index) == index {
+                        return (header2.ifm_data.ifi_ibytes, header2.ifm_data.ifi_obytes)
+                    }
+                }
+                offset += messageLength
+            }
+            return (nil, nil)
+        }
+    }
+}

--- a/QuickNetStats/Managers/LocationPermissionManager.swift
+++ b/QuickNetStats/Managers/LocationPermissionManager.swift
@@ -1,0 +1,82 @@
+//
+//  LocationPermissionManager.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-07.
+//
+
+import Foundation
+import Combine
+import CoreLocation
+
+/// The app-level view of Location Services authorization, collapsed to the three
+/// states the opt-in toggle cares about.
+enum LocationAuthorizationState {
+    case notDetermined
+    case authorized
+    case denied
+}
+
+/// Owns the `CLLocationManager` used solely to unlock CoreWLAN's location-gated
+/// SSID/BSSID reads. Never requests a location fix. This is the ONLY file that
+/// imports CoreLocation.
+class LocationPermissionManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+
+    /// The current authorization state; updates whenever the system reports a change.
+    @Published private(set) var state: LocationAuthorizationState
+
+    private let manager: CLLocationManager
+
+    /// Pending grant continuation from `requestAuthorization(onGrant:)`; fired once
+    /// the user answers the system prompt with a grant, discarded on refusal.
+    private var onGrant: (() -> Void)?
+
+    override init() {
+        let manager = CLLocationManager()
+        self.manager = manager
+        self.state = Self.state(from: manager.authorizationStatus)
+        super.init()
+        manager.delegate = self
+    }
+
+    /// Shows the system location prompt (only possible while `.notDetermined`) and
+    /// runs `onGrant` if the user authorizes.
+    func requestAuthorization(onGrant: @escaping () -> Void) {
+        self.onGrant = onGrant
+        manager.requestWhenInUseAuthorization()
+    }
+
+    /// Delegate callbacks are not actor-isolated; hop to the main actor before
+    /// touching published state.
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            self.apply(status)
+        }
+    }
+
+    /// Publishes the new state and settles the pending grant continuation.
+    private func apply(_ status: CLAuthorizationStatus) {
+        state = Self.state(from: status)
+        switch state {
+        case .authorized:
+            onGrant?()
+            onGrant = nil
+        case .denied:
+            onGrant = nil
+        case .notDetermined:
+            break
+        }
+    }
+
+    /// Collapses `CLAuthorizationStatus` to the app's three-state view. Unknown
+    /// future cases degrade to `.denied` (no prompt, nothing displayed).
+    nonisolated static func state(from status: CLAuthorizationStatus) -> LocationAuthorizationState {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .authorizedAlways, .authorizedWhenInUse: return .authorized
+        case .denied, .restricted: return .denied
+        @unknown default: return .denied
+        }
+    }
+}

--- a/QuickNetStats/Managers/NetworkDetailsManager.swift
+++ b/QuickNetStats/Managers/NetworkDetailsManager.swift
@@ -17,33 +17,47 @@ class NetworkDetailsManager: ObservableObject {
     /// The public IP of this machine.
     @Published var publicIP: String?
 
+    /// The Wi-Fi network name (SSID) of the primary interface, or nil off Wi-Fi /
+    /// without Location Services authorization. Gated for display by
+    /// `Settings.showNetworkNames`; the read itself is harmless when unauthorized.
+    @Published var ssid: String?
+
     /// The URLSession used to fetch the public IP (injectable for testing).
     /// Defaults to the shared 5-second-timeout reachability session.
     private let session: URLSession
 
-    /// Creates a manager with the given session.
-    /// - Parameter session: The session used for the public IP lookup.
-    init(session: URLSession = .reachabilitySession) {
+    /// Reads the Wi-Fi SSID (injectable for testing).
+    private let wifiReader: WifiReading
+
+    /// Creates a manager with the given session and Wi-Fi reader.
+    /// - Parameters:
+    ///   - session: The session used for the public IP lookup.
+    ///   - wifiReader: The reader used for the Wi-Fi SSID.
+    init(session: URLSession = .reachabilitySession, wifiReader: WifiReading = WifiReader()) {
         self.session = session
+        self.wifiReader = wifiReader
     }
 
-    /// Populate the published attributes for public and private IP.
+    /// Populate the published attributes for public and private IP and the SSID.
     func getAddresses() async {
         self.publicIP = await fetchPublicIpAddress()
         self.privateIP = getPrivateIPAddress()
+        self.ssid = wifiReader.currentSSID()
     }
-    
+
     /// Delete the old IPs then populate the published attributes for public and private IP.
     /// Use this to trigger UI updates every time the method is called
     func deleteAndGetAddresses() async {
-        
+
         // Delete the old values
         self.publicIP = nil
         self.privateIP = nil
-        
+        self.ssid = nil
+
         // Compute new values
         self.publicIP = await fetchPublicIpAddress()
         self.privateIP = getPrivateIPAddress()
+        self.ssid = wifiReader.currentSSID()
     }
     
     /**

--- a/QuickNetStats/Managers/NetworkDetailsManager.swift
+++ b/QuickNetStats/Managers/NetworkDetailsManager.swift
@@ -29,6 +29,10 @@ class NetworkDetailsManager: ObservableObject {
     /// Reads the Wi-Fi SSID (injectable for testing).
     private let wifiReader: WifiReading
 
+    /// Retains the connection-change subscription so `observeConnectionChanges`
+    /// only ever subscribes once.
+    private var connectionChangeCancellable: AnyCancellable?
+
     /// Creates a manager with the given session and Wi-Fi reader.
     /// - Parameters:
     ///   - session: The session used for the public IP lookup.
@@ -58,6 +62,16 @@ class NetworkDetailsManager: ObservableObject {
         self.publicIP = await fetchPublicIpAddress()
         self.privateIP = getPrivateIPAddress()
         self.ssid = wifiReader.currentSSID()
+    }
+
+    /// Subscribes to network-stats changes so the public/private IPs and SSID are
+    /// refreshed via `deleteAndGetAddresses()` when the active connection changes
+    /// while the popover is open. Idempotent: repeated calls subscribe only once.
+    func observeConnectionChanges(_ publisher: AnyPublisher<NetworkStats, Never>) {
+        guard connectionChangeCancellable == nil else { return }
+        connectionChangeCancellable = publisher.sink { [weak self] _ in
+            Task { await self?.deleteAndGetAddresses() }
+        }
     }
     
     /**

--- a/QuickNetStats/Managers/PathReader.swift
+++ b/QuickNetStats/Managers/PathReader.swift
@@ -1,0 +1,149 @@
+//
+//  PathReader.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-06.
+//
+
+import Foundation
+import Network
+
+/// A one-shot read of `NWPath` facts: protocol-support flags plus the other usable
+/// interfaces beside the primary. Flags are optional so a timeout/loss (empty
+/// snapshot) is distinguishable from a real all-false path.
+struct PathSnapshot: Equatable {
+    var supportsIPv4: Bool?
+    var supportsIPv6: Bool?
+    var supportsDNS: Bool?
+    /// Other usable interfaces beside the primary, e.g. `["Ethernet (en1)"]`.
+    var otherInterfaces: [String] = []
+}
+
+/// A seam over a one-shot `NWPathMonitor` so the manager stays testable.
+protocol PathReading {
+    func snapshot(excluding primaryBSDName: String?) async -> PathSnapshot
+}
+
+/// Reads a single `NWPath` by starting an `NWPathMonitor`, awaiting its first
+/// update (delivered immediately on start), then cancelling. Races a timeout so a
+/// pathological monitor can never hang `fetchDetails`; on timeout it returns an
+/// empty snapshot.
+struct PathReader: PathReading {
+
+    /// Seconds to wait for the monitor's first callback before giving up.
+    private let timeout: TimeInterval
+
+    init(timeout: TimeInterval = 2.0) {
+        self.timeout = timeout
+    }
+
+    /// Returns the first `NWPath` snapshot, or an empty snapshot if the monitor
+    /// does not report within `timeout`. `primaryBSDName` is excluded from
+    /// `otherInterfaces`.
+    func snapshot(excluding primaryBSDName: String?) async -> PathSnapshot {
+        await withTaskGroup(of: PathSnapshot.self) { group in
+            group.addTask { await Self.firstPath(excluding: primaryBSDName) }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(timeout))
+                return PathSnapshot()   // empty on timeout
+            }
+            let winner = await group.next() ?? PathSnapshot()
+            group.cancelAll()           // loser resumes via onCancel / a thrown sleep
+            return winner
+        }
+    }
+
+    // MARK: - One-shot monitor
+
+    /// Owns the continuation and guarantees it is resumed exactly once, whichever of
+    /// the monitor's first callback or the task-cancellation handler wins — and
+    /// whatever order `attach`/`resume` arrive in (a resume before attach is stashed).
+    private final class ResumeGuard {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<PathSnapshot, Never>?
+        private var pending: PathSnapshot?
+        private var done = false
+
+        /// Registers the continuation; delivers a stashed value if a resume already raced ahead.
+        func attach(_ continuation: CheckedContinuation<PathSnapshot, Never>) {
+            lock.lock()
+            if done { lock.unlock(); return }
+            if let value = pending {
+                done = true
+                pending = nil
+                lock.unlock()
+                continuation.resume(returning: value)
+            } else {
+                self.continuation = continuation
+                lock.unlock()
+            }
+        }
+
+        /// Resumes with `value` once; if the continuation isn't attached yet, stashes it.
+        func resume(with value: PathSnapshot) {
+            lock.lock()
+            if done { lock.unlock(); return }
+            if let continuation {
+                done = true
+                self.continuation = nil
+                lock.unlock()
+                continuation.resume(returning: value)
+            } else {
+                pending = value
+                lock.unlock()
+            }
+        }
+    }
+
+    /// Starts a monitor, resumes on its first path callback, and resumes with an
+    /// empty snapshot on task cancellation (so a cancelled child never leaves the
+    /// task group hanging when the timeout wins the race).
+    private static func firstPath(excluding primaryBSDName: String?) async -> PathSnapshot {
+        let monitor = NWPathMonitor()
+        let queue = DispatchQueue(label: "com.federicoimberti.quicknetstats.pathreader")
+        let guardBox = ResumeGuard()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<PathSnapshot, Never>) in
+                monitor.pathUpdateHandler = { path in
+                    let snapshot = Self.snapshot(from: path, excluding: primaryBSDName)
+                    monitor.cancel()
+                    guardBox.resume(with: snapshot)
+                }
+                guardBox.attach(continuation)
+                monitor.start(queue: queue)
+            }
+        } onCancel: {
+            monitor.cancel()
+            guardBox.resume(with: PathSnapshot())
+        }
+    }
+
+    /// Builds a `PathSnapshot` from a live `NWPath`, formatting each non-primary,
+    /// non-loopback available interface as "TypeLabel (bsdName)".
+    private static func snapshot(from path: NWPath, excluding primaryBSDName: String?) -> PathSnapshot {
+        var result = PathSnapshot()
+        result.supportsIPv4 = path.supportsIPv4
+        result.supportsIPv6 = path.supportsIPv6
+        result.supportsDNS = path.supportsDNS
+        result.otherInterfaces = path.availableInterfaces.compactMap { interface in
+            guard interface.name != primaryBSDName,
+                  let label = Self.typeLabel(interface.type) else { return nil }
+            return "\(label) (\(interface.name))"
+        }
+        return result
+    }
+
+    /// Maps an `NWInterface.InterfaceType` to a display label; loopback is excluded
+    /// entirely (nil), unknown/other → "Other".
+    private static func typeLabel(_ type: NWInterface.InterfaceType) -> String? {
+        switch type {
+        case .wifi: return "Wi-Fi"
+        case .wiredEthernet: return "Ethernet"
+        case .cellular: return "Cellular"
+        case .loopback: return nil
+        case .other: return "Other"
+        @unknown default: return "Other"
+        }
+    }
+}

--- a/QuickNetStats/Managers/SystemConfigReader.swift
+++ b/QuickNetStats/Managers/SystemConfigReader.swift
@@ -1,0 +1,87 @@
+//
+//  SystemConfigReader.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+import SystemConfiguration
+// DHCP lease helpers live in an explicit submodule not re-exported by the umbrella.
+import SystemConfiguration.SCDynamicStoreCopyDHCPInfo
+
+/// A read-only snapshot of `SCDynamicStore` network state for the primary service.
+struct SystemConfigSnapshot: Equatable {
+    var primaryInterface: String?
+    var primaryInterfaceDisplayName: String?
+    var primaryService: String?
+    var routerAddress: String?
+    var dnsServers: [String] = []
+    var searchDomains: [String] = []
+    var subnetMask: String?
+    var dhcpLeaseExpiry: Date?
+    var hostname: String?
+}
+
+/// A seam over `SystemConfiguration` reads so the manager stays testable.
+protocol SystemConfigReading {
+    func snapshot() -> SystemConfigSnapshot
+}
+
+/// Reads router/DNS/subnet/DHCP/hostname facts from the live `SCDynamicStore`.
+/// All reads are optional-safe: any key that is missing simply leaves its field nil.
+struct SystemConfigReader: SystemConfigReading {
+
+    /// Builds a snapshot from the current dynamic store. Sandbox-safe, no prompts.
+    func snapshot() -> SystemConfigSnapshot {
+        var result = SystemConfigSnapshot()
+
+        guard let store = SCDynamicStoreCreate(nil, "QuickNetStats" as CFString, nil, nil) else {
+            return result
+        }
+
+        // Global IPv4: router + primary interface/service identifiers.
+        if let ipv4 = SCDynamicStoreCopyValue(store, "State:/Network/Global/IPv4" as CFString) as? [String: Any] {
+            result.routerAddress = ipv4["Router"] as? String
+            result.primaryInterface = ipv4["PrimaryInterface"] as? String
+            result.primaryService = ipv4["PrimaryService"] as? String
+        }
+
+        // Global DNS: resolvers + search domains.
+        if let dns = SCDynamicStoreCopyValue(store, "State:/Network/Global/DNS" as CFString) as? [String: Any] {
+            result.dnsServers = dns["ServerAddresses"] as? [String] ?? []
+            result.searchDomains = dns["SearchDomains"] as? [String] ?? []
+        }
+
+        // Per-service IPv4: subnet mask, and DHCP lease expiry (if the service uses DHCP).
+        if let service = result.primaryService {
+            let serviceKey = "State:/Network/Service/\(service)/IPv4" as CFString
+            if let serviceIPv4 = SCDynamicStoreCopyValue(store, serviceKey) as? [String: Any] {
+                result.subnetMask = (serviceIPv4["SubnetMasks"] as? [String])?.first
+            }
+
+            if let dhcpInfo = SCDynamicStoreCopyDHCPInfo(store, service as CFString) {
+                result.dhcpLeaseExpiry = DHCPInfoGetLeaseExpirationTime(dhcpInfo) as Date?
+            }
+        }
+
+        // Local hostname (the ".local" Bonjour name, minus the suffix).
+        result.hostname = SCDynamicStoreCopyLocalHostName(store) as String?
+
+        // Human-readable display name for the primary interface, if resolvable.
+        if let primary = result.primaryInterface {
+            result.primaryInterfaceDisplayName = Self.displayName(forBSD: primary)
+        }
+
+        return result
+    }
+
+    /// Maps a BSD interface name (e.g. "en0") to its localized display name ("Wi-Fi").
+    private static func displayName(forBSD bsdName: String) -> String? {
+        guard let interfaces = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] else { return nil }
+        for interface in interfaces where SCNetworkInterfaceGetBSDName(interface) as String? == bsdName {
+            return SCNetworkInterfaceGetLocalizedDisplayName(interface) as String?
+        }
+        return nil
+    }
+}

--- a/QuickNetStats/Managers/SystemConfigReader.swift
+++ b/QuickNetStats/Managers/SystemConfigReader.swift
@@ -10,17 +10,30 @@ import SystemConfiguration
 // DHCP lease helpers live in an explicit submodule not re-exported by the umbrella.
 import SystemConfiguration.SCDynamicStoreCopyDHCPInfo
 
+/// Active system proxies for the primary service; each "host:port" or nil.
+struct ProxySnapshot: Equatable {
+    var http: String?
+    var https: String?
+    var socks: String?
+}
+
 /// A read-only snapshot of `SCDynamicStore` network state for the primary service.
 struct SystemConfigSnapshot: Equatable {
     var primaryInterface: String?
     var primaryInterfaceDisplayName: String?
     var primaryService: String?
     var routerAddress: String?
+    var ipv6Router: String?
     var dnsServers: [String] = []
     var searchDomains: [String] = []
     var subnetMask: String?
+    var ipv4ConfigMethod: String?
+    var dhcpServer: String?
+    var dhcpLeaseStart: Date?
     var dhcpLeaseExpiry: Date?
     var hostname: String?
+    var computerName: String?
+    var proxies = ProxySnapshot()
 }
 
 /// A seam over `SystemConfiguration` reads so the manager stays testable.
@@ -47,26 +60,43 @@ struct SystemConfigReader: SystemConfigReading {
             result.primaryService = ipv4["PrimaryService"] as? String
         }
 
+        // Global IPv6: router (present only when the primary service has IPv6 routing).
+        if let ipv6 = SCDynamicStoreCopyValue(store, "State:/Network/Global/IPv6" as CFString) as? [String: Any] {
+            result.ipv6Router = ipv6["Router"] as? String
+        }
+
         // Global DNS: resolvers + search domains.
         if let dns = SCDynamicStoreCopyValue(store, "State:/Network/Global/DNS" as CFString) as? [String: Any] {
             result.dnsServers = dns["ServerAddresses"] as? [String] ?? []
             result.searchDomains = dns["SearchDomains"] as? [String] ?? []
         }
 
-        // Per-service IPv4: subnet mask, and DHCP lease expiry (if the service uses DHCP).
+        // Per-service IPv4: subnet mask, config method, and DHCP facts (if applicable).
         if let service = result.primaryService {
             let serviceKey = "State:/Network/Service/\(service)/IPv4" as CFString
             if let serviceIPv4 = SCDynamicStoreCopyValue(store, serviceKey) as? [String: Any] {
                 result.subnetMask = (serviceIPv4["SubnetMasks"] as? [String])?.first
             }
 
+            result.ipv4ConfigMethod = Self.ipv4ConfigMethod(store: store, service: service)
+
             if let dhcpInfo = SCDynamicStoreCopyDHCPInfo(store, service as CFString) {
                 result.dhcpLeaseExpiry = DHCPInfoGetLeaseExpirationTime(dhcpInfo) as Date?
+                result.dhcpLeaseStart = DHCPInfoGetLeaseStartTime(dhcpInfo) as Date?
+                // DHCP option 54 = Server Identifier: the DHCP server's 4-byte IPv4.
+                if let serverData = DHCPInfoGetOptionData(dhcpInfo, 54) as Data? {
+                    result.dhcpServer = Self.ipv4String(from: serverData)
+                }
             }
         }
 
+        result.proxies = Self.proxies(store: store)
+
         // Local hostname (the ".local" Bonjour name, minus the suffix).
         result.hostname = SCDynamicStoreCopyLocalHostName(store) as String?
+
+        // User-friendly computer name ("Federico's MacBook Pro").
+        result.computerName = SCDynamicStoreCopyComputerName(store, nil) as String?
 
         // Human-readable display name for the primary interface, if resolvable.
         if let primary = result.primaryInterface {
@@ -74,6 +104,60 @@ struct SystemConfigReader: SystemConfigReading {
         }
 
         return result
+    }
+
+    /// The IPv4 `ConfigMethod` ("DHCP", "Manual", "LinkLocal"…) for the primary
+    /// service. Prefers the persisted `Setup:` domain and falls back to the live
+    /// `State:` domain, which is where a DHCP-assigned method actually appears.
+    private static func ipv4ConfigMethod(store: SCDynamicStore, service: String) -> String? {
+        for domain in ["Setup", "State"] {
+            let key = "\(domain):/Network/Service/\(service)/IPv4" as CFString
+            if let dict = SCDynamicStoreCopyValue(store, key) as? [String: Any],
+               let method = dict["ConfigMethod"] as? String {
+                return method
+            }
+        }
+        return nil
+    }
+
+    /// Reads the active HTTP/HTTPS/SOCKS proxies from `SCDynamicStoreCopyProxies`.
+    /// Each proxy is included only when its `*Enable` flag is 1.
+    private static func proxies(store: SCDynamicStore) -> ProxySnapshot {
+        guard let dict = SCDynamicStoreCopyProxies(store) as? [String: Any] else {
+            return ProxySnapshot()
+        }
+        return ProxySnapshot(
+            http: endpoint(in: dict, enable: kSCPropNetProxiesHTTPEnable,
+                           host: kSCPropNetProxiesHTTPProxy, port: kSCPropNetProxiesHTTPPort),
+            https: endpoint(in: dict, enable: kSCPropNetProxiesHTTPSEnable,
+                            host: kSCPropNetProxiesHTTPSProxy, port: kSCPropNetProxiesHTTPSPort),
+            socks: endpoint(in: dict, enable: kSCPropNetProxiesSOCKSEnable,
+                            host: kSCPropNetProxiesSOCKSProxy, port: kSCPropNetProxiesSOCKSPort)
+        )
+    }
+
+    /// Formats one proxy as "host:port" (or just "host" when no port is set) when
+    /// its enable flag is 1; nil when disabled or the host is missing/empty.
+    private static func endpoint(
+        in dict: [String: Any],
+        enable: CFString,
+        host: CFString,
+        port: CFString
+    ) -> String? {
+        guard (dict[enable as String] as? Int) == 1,
+              let hostValue = dict[host as String] as? String, !hostValue.isEmpty else {
+            return nil
+        }
+        if let portValue = dict[port as String] as? Int {
+            return "\(hostValue):\(portValue)"
+        }
+        return hostValue
+    }
+
+    /// Formats a 4-byte IPv4 address blob (e.g. DHCP option 54) as a dotted quad.
+    private static func ipv4String(from data: Data) -> String? {
+        guard data.count == 4 else { return nil }
+        return data.map { String($0) }.joined(separator: ".")
     }
 
     /// Maps a BSD interface name (e.g. "en0") to its localized display name ("Wi-Fi").

--- a/QuickNetStats/Managers/UpdateManager.swift
+++ b/QuickNetStats/Managers/UpdateManager.swift
@@ -12,7 +12,7 @@ struct GitHubRelease: Decodable {
     let tagName: String
     let htmlUrl: String
     
-    enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey { 
         case tagName = "tag_name"
         case htmlUrl = "html_url"
     }

--- a/QuickNetStats/Managers/UpdateManager.swift
+++ b/QuickNetStats/Managers/UpdateManager.swift
@@ -108,9 +108,35 @@ class UpdateManager: ObservableObject {
         tag.replacingOccurrences(of: "^[vV]\\.?", with: "", options: .regularExpression)
     }
 
-    /// Simple semantic version comparison
-    /// - Returns True if the current version is not the latest one
+    /// Pre-release-aware version comparison.
+    ///
+    /// Each version is split into a numeric base (up to the first "-") and an optional pre-release
+    /// suffix, e.g. "3.0.0-Beta-2" -> base "3.0.0", suffix "Beta-2".
+    /// - Different bases: a numeric comparison of the bases decides.
+    /// - Equal bases: the remote is newer only when the local build is a pre-release and the remote
+    ///   is the stable release (the stable release supersedes its own betas). Two pre-releases with
+    ///   the same base are treated as equal — GitHub's /releases/latest endpoint never returns a
+    ///   pre-release, so that case is unreachable in practice.
+    /// - Returns True if the remote version is newer than the local one
     func isVersion(_ remote: String, newerThan local: String) -> Bool {
-        return remote.compare(local, options: .numeric) == .orderedDescending
+        let remoteBase = String(remote.prefix(while: { $0 != "-" }))
+        let localBase = String(local.prefix(while: { $0 != "-" }))
+
+        guard remoteBase == localBase else {
+            return remoteBase.compare(localBase, options: .numeric) == .orderedDescending
+        }
+
+        // Equal bases: a stable remote (no suffix) supersedes a pre-release local.
+        return remote == remoteBase && local != localBase
+    }
+
+    /// Whether a version string denotes a beta build (contains "beta", case-insensitive).
+    static func isBetaVersion(_ version: String) -> Bool {
+        version.range(of: "beta", options: .caseInsensitive) != nil
+    }
+
+    /// Whether the currently running build is a beta.
+    var isBetaBuild: Bool {
+        Self.isBetaVersion(currentVersion)
     }
 }

--- a/QuickNetStats/Managers/WifiReader.swift
+++ b/QuickNetStats/Managers/WifiReader.swift
@@ -21,16 +21,22 @@ struct WifiSnapshot: Equatable {
     var rssiDBm: Int?
     var noiseDBm: Int?
     var txRateMbps: Double?
+    var bssid: String?
 }
 
 /// A seam over CoreWLAN so the manager stays testable.
 protocol WifiReading {
     func snapshot(for bsdName: String) -> WifiSnapshot?
+    /// The SSID of the default Wi-Fi interface; nil off Wi-Fi or when Location
+    /// Services authorization is missing.
+    func currentSSID() -> String?
 }
 
 /// Reads channel/band/width/PHY/security and RF metrics from CoreWLAN. Returns
 /// `nil` for non-Wi-Fi interfaces or when Wi-Fi is off. This is the ONLY file that
-/// imports CoreWLAN. **`ssid()`/`bssid()` are location-gated and never called.**
+/// imports CoreWLAN. **`ssid()`/`bssid()` are read here (the sole exception to the
+/// project-wide prohibition); they return nil without Location Services
+/// authorization — see `LocationPermissionManager`.**
 ///
 /// Enum fields are mapped by `rawValue` rather than by Swift-imported case names,
 /// which sidesteps the fragile acronym casing of `CWSecurity` (`.WEP`/`.OWE`) and
@@ -70,7 +76,16 @@ struct WifiReader: WifiReading {
         let txRate = interface.transmitRate()
         snapshot.txRateMbps = txRate > 0 ? txRate : nil
 
+        // Location-gated: nil without Location Services authorization (graceful).
+        snapshot.bssid = interface.bssid()
+
         return snapshot
+    }
+
+    /// The SSID of the default Wi-Fi interface, or nil off Wi-Fi / when Location
+    /// Services authorization is missing (CoreWLAN returns nil, never prompts).
+    func currentSSID() -> String? {
+        CWWiFiClient.shared().interface()?.ssid()
     }
 
     // MARK: - Enum mapping (by rawValue)

--- a/QuickNetStats/Managers/WifiReader.swift
+++ b/QuickNetStats/Managers/WifiReader.swift
@@ -1,0 +1,132 @@
+//
+//  WifiReader.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+import CoreWLAN
+
+/// A read-only snapshot of Wi-Fi RF/PHY facts for one interface.
+struct WifiSnapshot: Equatable {
+    var channelNumber: Int?
+    var band: String?
+    var channelWidthMHz: Int?
+    var phyMode: String?
+    var security: String?
+    var countryCode: String?
+    var rssiDBm: Int?
+    var noiseDBm: Int?
+    var txRateMbps: Double?
+}
+
+/// A seam over CoreWLAN so the manager stays testable.
+protocol WifiReading {
+    func snapshot(for bsdName: String) -> WifiSnapshot?
+}
+
+/// Reads channel/band/width/PHY/security and RF metrics from CoreWLAN. Returns
+/// `nil` for non-Wi-Fi interfaces or when Wi-Fi is off. This is the ONLY file that
+/// imports CoreWLAN. **`ssid()`/`bssid()` are location-gated and never called.**
+///
+/// Enum fields are mapped by `rawValue` rather than by Swift-imported case names,
+/// which sidesteps the fragile acronym casing of `CWSecurity` (`.WEP`/`.OWE`) and
+/// degrades any unknown/future value to `nil` (row omitted) instead of crashing.
+struct WifiReader: WifiReading {
+
+    /// Builds a Wi-Fi snapshot for the given BSD interface name, or nil if it is
+    /// not a Wi-Fi interface / Wi-Fi is unavailable.
+    func snapshot(for bsdName: String) -> WifiSnapshot? {
+        guard let interface = CWWiFiClient.shared().interface(withName: bsdName) else {
+            return nil
+        }
+
+        var snapshot = WifiSnapshot()
+
+        if let channel = interface.wlanChannel() {
+            snapshot.channelNumber = channel.channelNumber
+            snapshot.band = Self.bandText(channel.channelBand.rawValue)
+            snapshot.channelWidthMHz = Self.widthMHz(channel.channelWidth.rawValue)
+        }
+
+        snapshot.phyMode = Self.phyModeText(interface.activePHYMode().rawValue)
+        snapshot.security = Self.securityText(interface.security().rawValue)
+        snapshot.countryCode = interface.countryCode()
+
+        // CoreWLAN reports 0 dBm when RSSI/noise are unavailable; treat as nil.
+        let rssi = interface.rssiValue()
+        snapshot.rssiDBm = rssi == 0 ? nil : rssi
+        let noise = interface.noiseMeasurement()
+        snapshot.noiseDBm = noise == 0 ? nil : noise
+
+        let txRate = interface.transmitRate()
+        snapshot.txRateMbps = txRate > 0 ? txRate : nil
+
+        return snapshot
+    }
+
+    // MARK: - Enum mapping (by rawValue)
+
+    /// Maps `CWChannelBand` raw values to a display string; unknown/future → nil.
+    private static func bandText(_ rawValue: Int) -> String? {
+        switch rawValue {
+        case 1: return "2.4 GHz"
+        case 2: return "5 GHz"
+        case 3: return "6 GHz"
+        default: return nil          // kCWChannelBandUnknown (0) and future values
+        }
+    }
+
+    /// Maps `CWChannelWidth` raw values to a width in MHz; unknown/future → nil.
+    private static func widthMHz(_ rawValue: Int) -> Int? {
+        switch rawValue {
+        case 1: return 20
+        case 2: return 40
+        case 3: return 80
+        case 4: return 160
+        default: return nil          // kCWChannelWidthUnknown (0) and future values
+        }
+    }
+
+    /// Maps `CWPHYMode` raw values to an IEEE 802.11 name; none/future → nil.
+    private static func phyModeText(_ rawValue: Int) -> String? {
+        switch rawValue {
+        case 1: return "802.11a"
+        case 2: return "802.11b"
+        case 3: return "802.11g"
+        case 4: return "802.11n"
+        case 5: return "802.11ac"
+        case 6: return "802.11ax"
+        case 7: return "802.11be"
+        default: return nil          // kCWPHYModeNone (0) and future values
+        }
+    }
+
+    /// `CWSecurity` raw value → display string. `13` is WPA3 Transition
+    /// (WPA3/WPA2). Any value absent here (e.g. `kCWSecurityUnknown` = NSIntegerMax
+    /// or a future case) maps to nil, so the row degrades to omitted.
+    private static let securityNames: [Int: String] = [
+        0: "Open",
+        1: "WEP",
+        2: "WPA Personal",
+        3: "WPA/WPA2 Personal",
+        4: "WPA2 Personal",
+        5: "Personal",
+        6: "Dynamic WEP",
+        7: "WPA Enterprise",
+        8: "WPA/WPA2 Enterprise",
+        9: "WPA2 Enterprise",
+        10: "Enterprise",
+        11: "WPA3 Personal",
+        12: "WPA3 Enterprise",
+        13: "WPA2/WPA3 Personal",
+        14: "OWE",
+        15: "OWE Transition"
+    ]
+
+    /// Maps `CWSecurity` raw values to a display string; unknown/future → nil.
+    private static func securityText(_ rawValue: Int) -> String? {
+        securityNames[rawValue]
+    }
+}

--- a/QuickNetStats/Managers/WifiReader.swift
+++ b/QuickNetStats/Managers/WifiReader.swift
@@ -14,6 +14,8 @@ struct WifiSnapshot: Equatable {
     var band: String?
     var channelWidthMHz: Int?
     var phyMode: String?
+    var interfaceMode: String?   // "Station" | "IBSS" | "Host AP"
+    var txPowerMw: Int?
     var security: String?
     var countryCode: String?
     var rssiDBm: Int?
@@ -51,8 +53,13 @@ struct WifiReader: WifiReading {
         }
 
         snapshot.phyMode = Self.phyModeText(interface.activePHYMode().rawValue)
+        snapshot.interfaceMode = Self.modeText(interface.interfaceMode().rawValue)
         snapshot.security = Self.securityText(interface.security().rawValue)
         snapshot.countryCode = interface.countryCode()
+
+        // CoreWLAN reports 0 mW when transmit power is unavailable; treat as nil.
+        let txPower = interface.transmitPower()
+        snapshot.txPowerMw = txPower > 0 ? txPower : nil
 
         // CoreWLAN reports 0 dBm when RSSI/noise are unavailable; treat as nil.
         let rssi = interface.rssiValue()
@@ -86,6 +93,16 @@ struct WifiReader: WifiReading {
         case 3: return 80
         case 4: return 160
         default: return nil          // kCWChannelWidthUnknown (0) and future values
+        }
+    }
+
+    /// Maps `CWInterfaceMode` raw values to a display string; none (0)/future → nil.
+    static func modeText(_ rawValue: Int) -> String? {
+        switch rawValue {
+        case 1: return "Station"
+        case 2: return "IBSS"
+        case 3: return "Host AP"
+        default: return nil          // kCWInterfaceModeNone (0) and future values
         }
     }
 

--- a/QuickNetStats/Models/ConnectionDetails.swift
+++ b/QuickNetStats/Models/ConnectionDetails.swift
@@ -27,6 +27,7 @@ struct ConnectionDetails: Equatable {
         var bsdName: String?
         var displayName: String?
         var macAddress: String?
+        var bssid: String?
         var mtu: Int?
         var linkSpeedMbps: Double?
         /// Active media type for wired links ("1000baseT full-duplex"); nil off Ethernet.
@@ -112,14 +113,16 @@ struct ConnectionDetails: Equatable {
 
     /// Interface group rows in design order; nil fields are omitted. `rateUnit`
     /// governs only the "Link speed" row's unit family; it defaults to the native
-    /// bits unit so existing call sites and previews stay unchanged.
-    func interfaceRows(rateUnit: RateUnit = .bitsPerSecond) -> [DetailRow] {
+    func interfaceRows(rateUnit: RateUnit = .bitsPerSecond, includeBSSID: Bool = false) -> [DetailRow] {
         var rows: [DetailRow] = []
         if let name = Self.interfaceName(interface) {
             rows.append(DetailRow(label: "Name", value: name))
         }
         if let mac = interface.macAddress {
             rows.append(DetailRow(label: "MAC address", value: mac))
+        }
+        if includeBSSID, let bssid = interface.bssid {
+            rows.append(DetailRow(label: "BSSID", value: bssid))
         }
         if let mtu = interface.mtu {
             rows.append(DetailRow(label: "MTU", value: "\(mtu)"))
@@ -299,6 +302,7 @@ struct ConnectionDetails: Equatable {
             bsdName: "en0",
             displayName: "Wi-Fi",
             macAddress: "a4:83:e7:1a:2b:3c",
+            bssid: "aa:bb:cc:11:22:33",
             mtu: 1500,
             linkSpeedMbps: 866,
             supports: "IPv4 · IPv6 · DNS",

--- a/QuickNetStats/Models/ConnectionDetails.swift
+++ b/QuickNetStats/Models/ConnectionDetails.swift
@@ -1,0 +1,244 @@
+//
+//  ConnectionDetails.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+
+/// A single label–value pair rendered as one row in a details group.
+/// `id` is the label so a group cannot contain duplicate labels.
+struct DetailRow: Identifiable, Equatable {
+    let label: String
+    let value: String
+    var id: String { label }
+}
+
+/// One immutable snapshot of advanced network information, grouped to mirror the
+/// dropdown UI. Every leaf field is optional: a `nil` field means "could not be
+/// determined" and its row is simply omitted from the group's row array.
+struct ConnectionDetails: Equatable {
+
+    // MARK: - Groups
+
+    /// Physical/link-layer facts about the primary interface.
+    struct Interface: Equatable {
+        var bsdName: String?
+        var displayName: String?
+        var macAddress: String?
+        var mtu: Int?
+        var linkSpeedMbps: Double?
+    }
+
+    /// Layer-3 addressing for the primary interface.
+    struct Addressing: Equatable {
+        var ipv6Address: String?
+        var publicIPv6: String?
+        var subnetMask: String?
+        var routerAddress: String?
+        var hostname: String?
+    }
+
+    /// Name resolution and DHCP lease information.
+    struct DnsDhcp: Equatable {
+        var dnsServers: [String] = []
+        var searchDomains: [String] = []
+        var dhcpLeaseExpiry: Date?
+    }
+
+    /// Wi-Fi RF/PHY facts; the whole group is `nil` on non-Wi-Fi interfaces.
+    struct Wifi: Equatable {
+        var channelNumber: Int?
+        var band: String?          // "2.4 GHz" | "5 GHz" | "6 GHz"
+        var channelWidthMHz: Int?
+        var phyMode: String?       // "802.11ax"
+        var security: String?      // "WPA3 Personal"
+        var countryCode: String?
+    }
+
+    // MARK: - Properties
+
+    var interface = Interface()
+    var addressing = Addressing()
+    var dnsDhcp = DnsDhcp()
+    var wifi: Wifi?
+
+    // MARK: - Computed Rows
+
+    /// Interface group rows in design order; nil fields are omitted.
+    var interfaceRows: [DetailRow] {
+        var rows: [DetailRow] = []
+        if let name = Self.interfaceName(interface) {
+            rows.append(DetailRow(label: "Name", value: name))
+        }
+        if let mac = interface.macAddress {
+            rows.append(DetailRow(label: "MAC address", value: mac))
+        }
+        if let mtu = interface.mtu {
+            rows.append(DetailRow(label: "MTU", value: "\(mtu)"))
+        }
+        if let speed = interface.linkSpeedMbps {
+            rows.append(DetailRow(label: "Link speed", value: Self.linkSpeedText(speed)))
+        }
+        return rows
+    }
+
+    /// Addressing group rows in design order; nil fields are omitted.
+    var addressingRows: [DetailRow] {
+        var rows: [DetailRow] = []
+        if let router = addressing.routerAddress {
+            rows.append(DetailRow(label: "Router", value: router))
+        }
+        if let subnet = addressing.subnetMask {
+            rows.append(DetailRow(label: "Subnet mask", value: subnet))
+        }
+        if let ipv6 = addressing.ipv6Address {
+            rows.append(DetailRow(label: "IPv6 (local)", value: ipv6))
+        }
+        if let publicIPv6 = addressing.publicIPv6 {
+            rows.append(DetailRow(label: "Public IPv6", value: publicIPv6))
+        }
+        if let hostname = addressing.hostname {
+            rows.append(DetailRow(label: "Hostname", value: hostname))
+        }
+        return rows
+    }
+
+    /// DNS & DHCP group rows in design order; empty arrays / nil dates are omitted.
+    var dnsDhcpRows: [DetailRow] {
+        var rows: [DetailRow] = []
+        if !dnsDhcp.dnsServers.isEmpty {
+            rows.append(DetailRow(label: "DNS servers", value: dnsDhcp.dnsServers.joined(separator: ", ")))
+        }
+        if !dnsDhcp.searchDomains.isEmpty {
+            rows.append(DetailRow(label: "Search domains", value: dnsDhcp.searchDomains.joined(separator: ", ")))
+        }
+        if let lease = dnsDhcp.dhcpLeaseExpiry {
+            rows.append(DetailRow(
+                label: "DHCP lease expires",
+                value: lease.formatted(date: .abbreviated, time: .shortened)
+            ))
+        }
+        return rows
+    }
+
+    /// Wi-Fi group rows in design order; `[]` when `wifi == nil`.
+    var wifiRows: [DetailRow] {
+        guard let wifi else { return [] }
+        var rows: [DetailRow] = []
+        if let channel = Self.channelText(wifi) {
+            rows.append(DetailRow(label: "Channel", value: channel))
+        }
+        if let phy = wifi.phyMode {
+            rows.append(DetailRow(label: "PHY mode", value: phy))
+        }
+        if let security = wifi.security {
+            rows.append(DetailRow(label: "Security", value: security))
+        }
+        if let country = wifi.countryCode {
+            rows.append(DetailRow(label: "Country code", value: country))
+        }
+        return rows
+    }
+
+    // MARK: - Formatters
+
+    /// Composes the interface name as "displayName (bsdName)", falling back to
+    /// whichever single value is present, or `nil` when both are missing.
+    private static func interfaceName(_ interface: Interface) -> String? {
+        switch (interface.displayName, interface.bsdName) {
+        case let (display?, bsd?): return "\(display) (\(bsd))"
+        case let (display?, nil): return display
+        case let (nil, bsd?): return bsd
+        default: return nil
+        }
+    }
+
+    /// Formats a link speed in Mbps: whole Mbps below 1000, otherwise Gbps with
+    /// any trailing `.0` stripped ("866 Mbps", "1 Gbps", "2.5 Gbps").
+    /// Internal so `LiveConnectionStats` can reuse it for the Tx-rate row.
+    static func linkSpeedText(_ mbps: Double) -> String {
+        if mbps < 1000 {
+            return "\(Int(mbps.rounded())) Mbps"
+        }
+        let gbps = mbps / 1000
+        if gbps.truncatingRemainder(dividingBy: 1) == 0 {
+            return "\(Int(gbps)) Gbps"
+        }
+        return "\(gbps) Gbps"
+    }
+
+    /// Composes "44 · 5 GHz · 80 MHz", dropping nil pieces; `nil` when all are nil.
+    private static func channelText(_ wifi: Wifi) -> String? {
+        var parts: [String] = []
+        if let number = wifi.channelNumber { parts.append("\(number)") }
+        if let band = wifi.band { parts.append(band) }
+        if let width = wifi.channelWidthMHz { parts.append("\(width) MHz") }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    // MARK: - Mockups
+
+    /// Fully populated Wi-Fi snapshot for previews and tests.
+    static let mockWifi = ConnectionDetails(
+        interface: .init(
+            bsdName: "en0",
+            displayName: "Wi-Fi",
+            macAddress: "a4:83:e7:1a:2b:3c",
+            mtu: 1500,
+            linkSpeedMbps: 866
+        ),
+        addressing: .init(
+            ipv6Address: "2a00:1450:4009:82b::200e",
+            publicIPv6: "2a01:e11:1234:5678::1",
+            subnetMask: "255.255.255.0",
+            routerAddress: "192.168.1.1",
+            hostname: "Federicos-MacBook-Pro"
+        ),
+        dnsDhcp: .init(
+            dnsServers: ["192.168.1.1", "1.1.1.1"],
+            searchDomains: ["home"],
+            dhcpLeaseExpiry: Date().addingTimeInterval(86_400)
+        ),
+        wifi: .init(
+            channelNumber: 44,
+            band: "5 GHz",
+            channelWidthMHz: 80,
+            phyMode: "802.11ax",
+            security: "WPA3 Personal",
+            countryCode: "IT"
+        )
+    )
+
+    /// Wired snapshot: no Wi-Fi group, 1 Gbps link.
+    static let mockEthernet = ConnectionDetails(
+        interface: .init(
+            bsdName: "en5",
+            displayName: "Ethernet",
+            macAddress: "a4:83:e7:44:55:66",
+            mtu: 1500,
+            linkSpeedMbps: 1000
+        ),
+        addressing: .init(
+            ipv6Address: "2a00:1450:4009:82b::abcd",
+            subnetMask: "255.255.255.0",
+            routerAddress: "192.168.1.1",
+            hostname: "Federicos-MacBook-Pro"
+        ),
+        dnsDhcp: .init(
+            dnsServers: ["192.168.1.1"],
+            searchDomains: ["home"],
+            dhcpLeaseExpiry: Date().addingTimeInterval(86_400)
+        ),
+        wifi: nil
+    )
+
+    /// VPN snapshot: only router, DNS, and hostname are determinable.
+    static let mockVPN = ConnectionDetails(
+        interface: .init(bsdName: "utun3", displayName: "VPN"),
+        addressing: .init(routerAddress: "10.8.0.1", hostname: "Federicos-MacBook-Pro"),
+        dnsDhcp: .init(dnsServers: ["10.8.0.1"]),
+        wifi: nil
+    )
+}

--- a/QuickNetStats/Models/ConnectionDetails.swift
+++ b/QuickNetStats/Models/ConnectionDetails.swift
@@ -107,7 +107,13 @@ struct ConnectionDetails: Equatable {
     // MARK: - Computed Rows
 
     /// Interface group rows in design order; nil fields are omitted.
-    var interfaceRows: [DetailRow] {
+    /// Convenience alias for `interfaceRows(rateUnit:)` in the native (bits) unit.
+    var interfaceRows: [DetailRow] { interfaceRows(rateUnit: .bitsPerSecond) }
+
+    /// Interface group rows in design order; nil fields are omitted. `rateUnit`
+    /// governs only the "Link speed" row's unit family; it defaults to the native
+    /// bits unit so existing call sites and previews stay unchanged.
+    func interfaceRows(rateUnit: RateUnit = .bitsPerSecond) -> [DetailRow] {
         var rows: [DetailRow] = []
         if let name = Self.interfaceName(interface) {
             rows.append(DetailRow(label: "Name", value: name))
@@ -119,7 +125,7 @@ struct ConnectionDetails: Equatable {
             rows.append(DetailRow(label: "MTU", value: "\(mtu)"))
         }
         if let speed = interface.linkSpeedMbps {
-            rows.append(DetailRow(label: "Link speed", value: Self.linkSpeedText(speed)))
+            rows.append(DetailRow(label: "Link speed", value: Self.linkSpeedText(speed, in: rateUnit)))
         }
         if let media = interface.mediaDescription {
             rows.append(DetailRow(label: "Media", value: media))
@@ -250,9 +256,9 @@ struct ConnectionDetails: Equatable {
         }
     }
 
-    /// Formats a link speed in Mbps: whole Mbps below 1000, otherwise Gbps with
-    /// any trailing `.0` stripped ("866 Mbps", "1 Gbps", "2.5 Gbps").
-    /// Internal so `LiveConnectionStats` can reuse it for the Tx-rate row.
+    /// Formats a link speed in Mbps in its native bits unit: whole Mbps below 1000,
+    /// otherwise Gbps with any trailing `.0` stripped ("866 Mbps", "1 Gbps",
+    /// "2.5 Gbps"). Internal so `LiveConnectionStats` can reuse it for the Tx-rate row.
     static func linkSpeedText(_ mbps: Double) -> String {
         if mbps < 1000 {
             return "\(Int(mbps.rounded())) Mbps"
@@ -262,6 +268,18 @@ struct ConnectionDetails: Equatable {
             return "\(Int(gbps)) Gbps"
         }
         return "\(gbps) Gbps"
+    }
+
+    /// Formats a link speed in Mbps, displayed in `unit`. The native bits unit keeps
+    /// the historical `linkSpeedText(_:)` output byte-for-byte; the bytes unit routes
+    /// through `DataRate` after converting the Mbps value to bits per second.
+    static func linkSpeedText(_ mbps: Double, in unit: RateUnit) -> String {
+        switch unit {
+        case .bitsPerSecond:
+            return linkSpeedText(mbps)
+        case .bytesPerSecond:
+            return DataRate.text(bitsPerSecond: mbps * 1_000_000, in: .bytesPerSecond)
+        }
     }
 
     /// Composes "44 · 5 GHz · 80 MHz", dropping nil pieces; `nil` when all are nil.

--- a/QuickNetStats/Models/ConnectionDetails.swift
+++ b/QuickNetStats/Models/ConnectionDetails.swift
@@ -29,6 +29,12 @@ struct ConnectionDetails: Equatable {
         var macAddress: String?
         var mtu: Int?
         var linkSpeedMbps: Double?
+        /// Active media type for wired links ("1000baseT full-duplex"); nil off Ethernet.
+        var mediaDescription: String?
+        /// Pre-formatted NWPath capability list ("IPv4 · IPv6 · DNS"); nil when unknown.
+        var supports: String?
+        /// Other usable interfaces beside the primary, e.g. `["Ethernet (en1)"]`.
+        var otherInterfaces: [String] = []
     }
 
     /// Layer-3 addressing for the primary interface.
@@ -38,13 +44,28 @@ struct ConnectionDetails: Equatable {
         var subnetMask: String?
         var routerAddress: String?
         var hostname: String?
+        var ipv6Router: String?
+        var broadcastAddress: String?
+        /// IPv4 configuration method ("DHCP", "Manual", "LinkLocal"…).
+        var ipv4ConfigMethod: String?
+        var computerName: String?
     }
 
     /// Name resolution and DHCP lease information.
     struct DnsDhcp: Equatable {
         var dnsServers: [String] = []
         var searchDomains: [String] = []
+        var dhcpServer: String?
+        var dhcpLeaseStart: Date?
         var dhcpLeaseExpiry: Date?
+    }
+
+    /// Active system proxies for the primary service; each is "host:port" or nil
+    /// when that proxy type is disabled. The whole group's rows vanish when all nil.
+    struct Proxy: Equatable {
+        var httpProxy: String?
+        var httpsProxy: String?
+        var socksProxy: String?
     }
 
     /// Wi-Fi RF/PHY facts; the whole group is `nil` on non-Wi-Fi interfaces.
@@ -53,8 +74,26 @@ struct ConnectionDetails: Equatable {
         var band: String?          // "2.4 GHz" | "5 GHz" | "6 GHz"
         var channelWidthMHz: Int?
         var phyMode: String?       // "802.11ax"
+        var mode: String?          // "Station" | "IBSS" | "Host AP"
+        var txPowerMw: Int?
         var security: String?      // "WPA3 Personal"
         var countryCode: String?
+
+        /// Marketing Wi-Fi generation ("Wi-Fi 6", "Wi-Fi 6E", …) derived from the
+        /// PHY mode and band, both of which come from `WifiReader`'s closed value
+        /// set. `nil` when the PHY mode is unknown/unset, so its row is omitted.
+        var generation: String? {
+            switch phyMode {
+            case "802.11b": return "Wi-Fi 1"
+            case "802.11a": return "Wi-Fi 2"
+            case "802.11g": return "Wi-Fi 3"
+            case "802.11n": return "Wi-Fi 4"
+            case "802.11ac": return "Wi-Fi 5"
+            case "802.11ax": return band == "6 GHz" ? "Wi-Fi 6E" : "Wi-Fi 6"
+            case "802.11be": return "Wi-Fi 7"
+            default: return nil
+            }
+        }
     }
 
     // MARK: - Properties
@@ -62,6 +101,7 @@ struct ConnectionDetails: Equatable {
     var interface = Interface()
     var addressing = Addressing()
     var dnsDhcp = DnsDhcp()
+    var proxy = Proxy()
     var wifi: Wifi?
 
     // MARK: - Computed Rows
@@ -81,6 +121,15 @@ struct ConnectionDetails: Equatable {
         if let speed = interface.linkSpeedMbps {
             rows.append(DetailRow(label: "Link speed", value: Self.linkSpeedText(speed)))
         }
+        if let media = interface.mediaDescription {
+            rows.append(DetailRow(label: "Media", value: media))
+        }
+        if let supports = interface.supports {
+            rows.append(DetailRow(label: "Supports", value: supports))
+        }
+        if !interface.otherInterfaces.isEmpty {
+            rows.append(DetailRow(label: "Also available", value: interface.otherInterfaces.joined(separator: ", ")))
+        }
         return rows
     }
 
@@ -90,8 +139,14 @@ struct ConnectionDetails: Equatable {
         if let router = addressing.routerAddress {
             rows.append(DetailRow(label: "Router", value: router))
         }
+        if let ipv6Router = addressing.ipv6Router {
+            rows.append(DetailRow(label: "Router (IPv6)", value: ipv6Router))
+        }
         if let subnet = addressing.subnetMask {
             rows.append(DetailRow(label: "Subnet mask", value: subnet))
+        }
+        if let broadcast = addressing.broadcastAddress {
+            rows.append(DetailRow(label: "Broadcast", value: broadcast))
         }
         if let ipv6 = addressing.ipv6Address {
             rows.append(DetailRow(label: "IPv6 (local)", value: ipv6))
@@ -99,8 +154,14 @@ struct ConnectionDetails: Equatable {
         if let publicIPv6 = addressing.publicIPv6 {
             rows.append(DetailRow(label: "Public IPv6", value: publicIPv6))
         }
+        if let configMethod = addressing.ipv4ConfigMethod {
+            rows.append(DetailRow(label: "IPv4 config", value: configMethod))
+        }
         if let hostname = addressing.hostname {
             rows.append(DetailRow(label: "Hostname", value: hostname))
+        }
+        if let computerName = addressing.computerName {
+            rows.append(DetailRow(label: "Computer name", value: computerName))
         }
         return rows
     }
@@ -114,11 +175,36 @@ struct ConnectionDetails: Equatable {
         if !dnsDhcp.searchDomains.isEmpty {
             rows.append(DetailRow(label: "Search domains", value: dnsDhcp.searchDomains.joined(separator: ", ")))
         }
+        if let server = dnsDhcp.dhcpServer {
+            rows.append(DetailRow(label: "DHCP server", value: server))
+        }
+        if let start = dnsDhcp.dhcpLeaseStart {
+            rows.append(DetailRow(
+                label: "Lease started",
+                value: start.formatted(date: .abbreviated, time: .shortened)
+            ))
+        }
         if let lease = dnsDhcp.dhcpLeaseExpiry {
             rows.append(DetailRow(
                 label: "DHCP lease expires",
                 value: lease.formatted(date: .abbreviated, time: .shortened)
             ))
+        }
+        return rows
+    }
+
+    /// Proxy group rows in HTTP/HTTPS/SOCKS order; nil proxies are omitted, so an
+    /// all-nil `Proxy` yields `[]` and the group never renders (existing convention).
+    var proxyRows: [DetailRow] {
+        var rows: [DetailRow] = []
+        if let http = proxy.httpProxy {
+            rows.append(DetailRow(label: "HTTP", value: http))
+        }
+        if let https = proxy.httpsProxy {
+            rows.append(DetailRow(label: "HTTPS", value: https))
+        }
+        if let socks = proxy.socksProxy {
+            rows.append(DetailRow(label: "SOCKS", value: socks))
         }
         return rows
     }
@@ -132,6 +218,15 @@ struct ConnectionDetails: Equatable {
         }
         if let phy = wifi.phyMode {
             rows.append(DetailRow(label: "PHY mode", value: phy))
+        }
+        if let generation = wifi.generation {
+            rows.append(DetailRow(label: "Generation", value: generation))
+        }
+        if let mode = wifi.mode {
+            rows.append(DetailRow(label: "Mode", value: mode))
+        }
+        if let txPower = wifi.txPowerMw {
+            rows.append(DetailRow(label: "Tx power", value: "\(txPower) mW"))
         }
         if let security = wifi.security {
             rows.append(DetailRow(label: "Security", value: security))
@@ -187,25 +282,36 @@ struct ConnectionDetails: Equatable {
             displayName: "Wi-Fi",
             macAddress: "a4:83:e7:1a:2b:3c",
             mtu: 1500,
-            linkSpeedMbps: 866
+            linkSpeedMbps: 866,
+            supports: "IPv4 · IPv6 · DNS",
+            otherInterfaces: ["Ethernet (en5)"]
         ),
         addressing: .init(
             ipv6Address: "2a00:1450:4009:82b::200e",
             publicIPv6: "2a01:e11:1234:5678::1",
             subnetMask: "255.255.255.0",
             routerAddress: "192.168.1.1",
-            hostname: "Federicos-MacBook-Pro"
+            hostname: "Federicos-MacBook-Pro",
+            ipv6Router: "fe80::1",
+            broadcastAddress: "192.168.1.255",
+            ipv4ConfigMethod: "DHCP",
+            computerName: "Federico's MacBook Pro"
         ),
         dnsDhcp: .init(
             dnsServers: ["192.168.1.1", "1.1.1.1"],
             searchDomains: ["home"],
+            dhcpServer: "192.168.1.1",
+            dhcpLeaseStart: Date().addingTimeInterval(-3_600),
             dhcpLeaseExpiry: Date().addingTimeInterval(86_400)
         ),
+        proxy: .init(httpProxy: "proxy.local:8080", httpsProxy: "proxy.local:8080"),
         wifi: .init(
             channelNumber: 44,
             band: "5 GHz",
             channelWidthMHz: 80,
             phyMode: "802.11ax",
+            mode: "Station",
+            txPowerMw: 100,
             security: "WPA3 Personal",
             countryCode: "IT"
         )
@@ -218,17 +324,26 @@ struct ConnectionDetails: Equatable {
             displayName: "Ethernet",
             macAddress: "a4:83:e7:44:55:66",
             mtu: 1500,
-            linkSpeedMbps: 1000
+            linkSpeedMbps: 1000,
+            mediaDescription: "1000baseT full-duplex",
+            supports: "IPv4 · IPv6 · DNS",
+            otherInterfaces: ["Wi-Fi (en0)"]
         ),
         addressing: .init(
             ipv6Address: "2a00:1450:4009:82b::abcd",
             subnetMask: "255.255.255.0",
             routerAddress: "192.168.1.1",
-            hostname: "Federicos-MacBook-Pro"
+            hostname: "Federicos-MacBook-Pro",
+            ipv6Router: "fe80::abcd",
+            broadcastAddress: "192.168.1.255",
+            ipv4ConfigMethod: "Manual",
+            computerName: "Federico's MacBook Pro"
         ),
         dnsDhcp: .init(
             dnsServers: ["192.168.1.1"],
             searchDomains: ["home"],
+            dhcpServer: "192.168.1.1",
+            dhcpLeaseStart: Date().addingTimeInterval(-3_600),
             dhcpLeaseExpiry: Date().addingTimeInterval(86_400)
         ),
         wifi: nil

--- a/QuickNetStats/Models/DataRate.swift
+++ b/QuickNetStats/Models/DataRate.swift
@@ -1,0 +1,94 @@
+//
+//  DataRate.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-06.
+//
+
+import Foundation
+
+/// The unit family used to display a data rate. Its `rawValue` is the base-unit
+/// abbreviation so it can be stored directly via `@AppStorage`.
+enum RateUnit: String, CaseIterable, Identifiable {
+    case bitsPerSecond = "bps"
+    case bytesPerSecond = "B/s"
+
+    var id: String { rawValue }
+
+    /// Human-readable label for pickers, naming the family and a sample multiple.
+    var displayName: String {
+        switch self {
+        case .bitsPerSecond: return "Bits per second (Mbps)"
+        case .bytesPerSecond: return "Bytes per second (MB/s)"
+        }
+    }
+}
+
+/// Shared bits <-> bytes conversion and auto-scaling rate formatting. Single
+/// source of truth for the customizable Connection Details units: a rate is
+/// stored in its native family and converted only for display.
+enum DataRate {
+
+    // MARK: - Conversion
+
+    /// Bits per second to bytes per second (÷ 8).
+    static func bitsToBytes(_ bitsPerSecond: Double) -> Double { bitsPerSecond / 8 }
+
+    /// Bytes per second to bits per second (× 8).
+    static func bytesToBits(_ bytesPerSecond: Double) -> Double { bytesPerSecond * 8 }
+
+    // MARK: - Formatting
+
+    /// Formats a bits-per-second rate, displayed in `unit`. When `unit` is
+    /// `.bytesPerSecond` the value is converted (÷ 8) before scaling.
+    static func text(bitsPerSecond: Double, in unit: RateUnit) -> String {
+        switch unit {
+        case .bitsPerSecond:
+            return scaled(bitsPerSecond, units: bitUnits)
+        case .bytesPerSecond:
+            return scaled(bitsToBytes(bitsPerSecond), units: byteUnits)
+        }
+    }
+
+    /// Formats a bytes-per-second rate, displayed in `unit`. When `unit` is
+    /// `.bitsPerSecond` the value is converted (× 8) before scaling.
+    static func text(bytesPerSecond: Double, in unit: RateUnit) -> String {
+        switch unit {
+        case .bytesPerSecond:
+            return scaled(bytesPerSecond, units: byteUnits)
+        case .bitsPerSecond:
+            return scaled(bytesToBits(bytesPerSecond), units: bitUnits)
+        }
+    }
+
+    // MARK: - Private
+
+    private static let bitUnits = ["bps", "Kbps", "Mbps", "Gbps"]
+    private static let byteUnits = ["B/s", "KB/s", "MB/s", "GB/s"]
+
+    /// Scales `value` (in the base unit of `units`) down through base-1000 multiples
+    /// to the largest multiple ≥ 1, then renders it with up to two decimals and any
+    /// trailing zeros stripped ("866 Mbps", "1 Gbps", "2.5 Gbps", "26.25 MB/s").
+    private static func scaled(_ value: Double, units: [String]) -> String {
+        var magnitude = value
+        var index = 0
+        while magnitude >= 1_000, index < units.count - 1 {
+            magnitude /= 1_000
+            index += 1
+        }
+        return "\(trimmed(magnitude)) \(units[index])"
+    }
+
+    /// Rounds to at most two decimals and strips trailing zeros (and a dangling
+    /// decimal point), so whole values render without a fractional part.
+    private static func trimmed(_ value: Double) -> String {
+        let rounded = (value * 100).rounded() / 100
+        if rounded == rounded.rounded(.towardZero) {
+            return String(Int(rounded))
+        }
+        var text = String(format: "%.2f", rounded)
+        while text.hasSuffix("0") { text.removeLast() }
+        if text.hasSuffix(".") { text.removeLast() }
+        return text
+    }
+}

--- a/QuickNetStats/Models/LiveConnectionStats.swift
+++ b/QuickNetStats/Models/LiveConnectionStats.swift
@@ -1,0 +1,72 @@
+//
+//  LiveConnectionStats.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import Foundation
+
+/// One live sample of throughput and Wi-Fi RF metrics, published by
+/// `ConnectionDetailsManager` while the popover's Live section is active.
+/// Throughput fields stay `nil` until the second poll tick (a counter delta is
+/// needed); RF fields are `nil` on non-Wi-Fi interfaces.
+struct LiveConnectionStats: Equatable {
+
+    // MARK: - Properties
+
+    var downloadBytesPerSec: Double?
+    var uploadBytesPerSec: Double?
+    var rssiDBm: Int?
+    var noiseDBm: Int?
+    var txRateMbps: Double?
+
+    // MARK: - Computed Properties
+
+    /// Signal-to-noise ratio in dB: `rssi − noise` when both are present.
+    var snrDB: Int? {
+        guard let rssiDBm, let noiseDBm else { return nil }
+        return rssiDBm - noiseDBm
+    }
+
+    var rssiText: String? { rssiDBm.map { "\($0) dBm" } }
+    var noiseText: String? { noiseDBm.map { "\($0) dBm" } }
+    var snrText: String? { snrDB.map { "\($0) dB" } }
+    var txRateText: String? { txRateMbps.map { ConnectionDetails.linkSpeedText($0) } }
+    var downloadText: String? { downloadBytesPerSec.map { Self.rateText($0) } }
+    var uploadText: String? { uploadBytesPerSec.map { Self.rateText($0) } }
+
+    // MARK: - Formatters
+
+    /// Formats a byte-per-second rate with a magnitude-appropriate unit.
+    /// Whole bytes below 1 KB/s; one decimal for KB/s and above. Uses the C
+    /// locale (`String(format:)`) so the output is deterministic and testable.
+    static func rateText(_ bytesPerSec: Double) -> String {
+        if bytesPerSec < 1_000 {
+            return "\(Int(bytesPerSec.rounded())) B/s"
+        } else if bytesPerSec < 1_000_000 {
+            return String(format: "%.1f KB/s", bytesPerSec / 1_000)
+        } else if bytesPerSec < 1_000_000_000 {
+            return String(format: "%.1f MB/s", bytesPerSec / 1_000_000)
+        } else {
+            return String(format: "%.1f GB/s", bytesPerSec / 1_000_000_000)
+        }
+    }
+
+    // MARK: - Mockups
+
+    /// A live Wi-Fi sample with throughput and RF metrics.
+    static let mockLiveWifi = LiveConnectionStats(
+        downloadBytesPerSec: 1_200_000,
+        uploadBytesPerSec: 340_000,
+        rssiDBm: -52,
+        noiseDBm: -95,
+        txRateMbps: 866
+    )
+
+    /// A live wired sample with throughput only.
+    static let mockLiveWired = LiveConnectionStats(
+        downloadBytesPerSec: 8_500_000,
+        uploadBytesPerSec: 1_100_000
+    )
+}

--- a/QuickNetStats/Models/LiveConnectionStats.swift
+++ b/QuickNetStats/Models/LiveConnectionStats.swift
@@ -17,6 +17,11 @@ struct LiveConnectionStats: Equatable {
 
     var downloadBytesPerSec: Double?
     var uploadBytesPerSec: Double?
+    var downloadPacketsPerSec: Double?
+    var uploadPacketsPerSec: Double?
+    /// Combined in + out interface errors per second.
+    var errorsPerSec: Double?
+    var dropsPerSec: Double?
     var rssiDBm: Int?
     var noiseDBm: Int?
     var txRateMbps: Double?
@@ -35,6 +40,10 @@ struct LiveConnectionStats: Equatable {
     var txRateText: String? { txRateMbps.map { ConnectionDetails.linkSpeedText($0) } }
     var downloadText: String? { downloadBytesPerSec.map { Self.rateText($0) } }
     var uploadText: String? { uploadBytesPerSec.map { Self.rateText($0) } }
+    var downloadPacketsText: String? { downloadPacketsPerSec.map { Self.countRateText($0) } }
+    var uploadPacketsText: String? { uploadPacketsPerSec.map { Self.countRateText($0) } }
+    var errorsText: String? { errorsPerSec.map { Self.countRateText($0) } }
+    var dropsText: String? { dropsPerSec.map { Self.countRateText($0) } }
 
     // MARK: - Formatters
 
@@ -53,20 +62,34 @@ struct LiveConnectionStats: Equatable {
         }
     }
 
+    /// Formats a per-second count (packets/errors/drops) as a rounded integer plus
+    /// "/s" ("1234/s"). No thousands separator; sub-1 rates round to the nearest whole.
+    static func countRateText(_ perSec: Double) -> String {
+        "\(Int(perSec.rounded()))/s"
+    }
+
     // MARK: - Mockups
 
-    /// A live Wi-Fi sample with throughput and RF metrics.
+    /// A live Wi-Fi sample with throughput, counters, and RF metrics.
     static let mockLiveWifi = LiveConnectionStats(
         downloadBytesPerSec: 1_200_000,
         uploadBytesPerSec: 340_000,
+        downloadPacketsPerSec: 1_050,
+        uploadPacketsPerSec: 420,
+        errorsPerSec: 0,
+        dropsPerSec: 0,
         rssiDBm: -52,
         noiseDBm: -95,
         txRateMbps: 866
     )
 
-    /// A live wired sample with throughput only.
+    /// A live wired sample with throughput and counters but no RF metrics.
     static let mockLiveWired = LiveConnectionStats(
         downloadBytesPerSec: 8_500_000,
-        uploadBytesPerSec: 1_100_000
+        uploadBytesPerSec: 1_100_000,
+        downloadPacketsPerSec: 7_300,
+        uploadPacketsPerSec: 980,
+        errorsPerSec: 0,
+        dropsPerSec: 1
     )
 }

--- a/QuickNetStats/Models/LiveConnectionStats.swift
+++ b/QuickNetStats/Models/LiveConnectionStats.swift
@@ -37,13 +37,30 @@ struct LiveConnectionStats: Equatable {
     var rssiText: String? { rssiDBm.map { "\($0) dBm" } }
     var noiseText: String? { noiseDBm.map { "\($0) dBm" } }
     var snrText: String? { snrDB.map { "\($0) dB" } }
-    var txRateText: String? { txRateMbps.map { ConnectionDetails.linkSpeedText($0) } }
-    var downloadText: String? { downloadBytesPerSec.map { Self.rateText($0) } }
-    var uploadText: String? { uploadBytesPerSec.map { Self.rateText($0) } }
+    var txRateText: String? { txRateText(in: .bitsPerSecond) }
+    var downloadText: String? { downloadText(in: .bytesPerSecond) }
+    var uploadText: String? { uploadText(in: .bytesPerSecond) }
     var downloadPacketsText: String? { downloadPacketsPerSec.map { Self.countRateText($0) } }
     var uploadPacketsText: String? { uploadPacketsPerSec.map { Self.countRateText($0) } }
     var errorsText: String? { errorsPerSec.map { Self.countRateText($0) } }
     var dropsText: String? { dropsPerSec.map { Self.countRateText($0) } }
+
+    // MARK: - Unit-aware text
+
+    /// Wi-Fi Tx rate formatted in `unit` (native bits). `nil` when unmeasured.
+    func txRateText(in unit: RateUnit) -> String? {
+        txRateMbps.map { ConnectionDetails.linkSpeedText($0, in: unit) }
+    }
+
+    /// Download throughput formatted in `unit` (native bytes). `nil` when unmeasured.
+    func downloadText(in unit: RateUnit) -> String? {
+        downloadBytesPerSec.map { Self.rateText($0, in: unit) }
+    }
+
+    /// Upload throughput formatted in `unit` (native bytes). `nil` when unmeasured.
+    func uploadText(in unit: RateUnit) -> String? {
+        uploadBytesPerSec.map { Self.rateText($0, in: unit) }
+    }
 
     // MARK: - Formatters
 
@@ -59,6 +76,18 @@ struct LiveConnectionStats: Equatable {
             return String(format: "%.1f MB/s", bytesPerSec / 1_000_000)
         } else {
             return String(format: "%.1f GB/s", bytesPerSec / 1_000_000_000)
+        }
+    }
+
+    /// Formats a byte-per-second rate, displayed in `unit`. The native bytes unit keeps
+    /// the historical `rateText(_:)` output byte-for-byte; the bits unit routes through
+    /// `DataRate` after converting the value to bits per second.
+    static func rateText(_ bytesPerSec: Double, in unit: RateUnit) -> String {
+        switch unit {
+        case .bytesPerSecond:
+            return rateText(bytesPerSec)
+        case .bitsPerSecond:
+            return DataRate.text(bytesPerSecond: bytesPerSec, in: .bitsPerSecond)
         }
     }
 

--- a/QuickNetStats/Models/Settings.swift
+++ b/QuickNetStats/Models/Settings.swift
@@ -36,6 +36,10 @@ class Settings: ObservableObject {
         static let notifyInternetBehavior = "notifyInternetBehavior"
         static let notifyQualityBehavior = "notifyQualityBehavior"
         static let notifyInterfaceChanges = "notifyInterfaceChanges"
+        static let interfaceRateUnit = "interfaceRateUnit"
+        static let wifiRateUnit = "wifiRateUnit"
+        static let liveRateUnit = "liveRateUnit"
+        static let startLiveMonitoringOnOpen = "startLiveMonitoringOnOpen"
     }
     
     @AppStorage(UserDefaultsKeys.showSummaryInMenu)
@@ -72,5 +76,20 @@ class Settings: ObservableObject {
     
     @AppStorage(UserDefaultsKeys.notifyInterfaceChanges)
     var notifyInterfaceChanges: Bool = false
+
+    /// Display unit for the Interface "Link speed" row. Defaults to the native bits family.
+    @AppStorage(UserDefaultsKeys.interfaceRateUnit)
+    var interfaceRateUnit: RateUnit = .bitsPerSecond
+
+    /// Display unit for the Wi-Fi "Tx rate" row. Defaults to the native bits family.
+    @AppStorage(UserDefaultsKeys.wifiRateUnit)
+    var wifiRateUnit: RateUnit = .bitsPerSecond
+
+    /// Display unit for the Live "Download"/"Upload" rows. Defaults to the native bytes family.
+    @AppStorage(UserDefaultsKeys.liveRateUnit)
+    var liveRateUnit: RateUnit = .bytesPerSecond
+    
+    @AppStorage(UserDefaultsKeys.startLiveMonitoringOnOpen)
+    var startLiveMonitoringOnOpen: Bool = false
 
 }

--- a/QuickNetStats/Models/Settings.swift
+++ b/QuickNetStats/Models/Settings.swift
@@ -40,6 +40,7 @@ class Settings: ObservableObject {
         static let wifiRateUnit = "wifiRateUnit"
         static let liveRateUnit = "liveRateUnit"
         static let startLiveMonitoringOnOpen = "startLiveMonitoringOnOpen"
+        static let showNetworkNames = "showNetworkNames"
     }
     
     @AppStorage(UserDefaultsKeys.showSummaryInMenu)
@@ -91,5 +92,9 @@ class Settings: ObservableObject {
     
     @AppStorage(UserDefaultsKeys.startLiveMonitoringOnOpen)
     var startLiveMonitoringOnOpen: Bool = false
+
+    /// Opt-in display of the Wi-Fi SSID (main window) and BSSID (Connection Details).
+    @AppStorage(UserDefaultsKeys.showNetworkNames)
+    var showNetworkNames: Bool = false
 
 }

--- a/QuickNetStats/Models/Settings.swift
+++ b/QuickNetStats/Models/Settings.swift
@@ -31,6 +31,7 @@ class Settings: ObservableObject {
         static let showQualityInMenu = "showQualityInMenu"
         static let useAnimations = "useAnimations"
         static let isColorful = "isColorful"
+        static let keepDetailsExpanded = "keepDetailsExpanded"
         static let isNotificationActive = "isNotificationActive"
         static let notifyInternetBehavior = "notifyInternetBehavior"
         static let notifyQualityBehavior = "notifyQualityBehavior"
@@ -48,6 +49,9 @@ class Settings: ObservableObject {
     
     @AppStorage(UserDefaultsKeys.isColorful)
     var isColorful: Bool = true
+
+    @AppStorage(UserDefaultsKeys.keepDetailsExpanded)
+    var keepDetailsExpanded: Bool = false
     
     @AppStorage(UserDefaultsKeys.isNotificationActive)
     var isNotificationActive: Bool = false

--- a/QuickNetStats/QuickNetStatsApp.swift
+++ b/QuickNetStats/QuickNetStatsApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import UserNotifications
 
 @main
@@ -33,6 +34,20 @@ struct QuickNetStatsApp: App {
                 .padding()
                 .frame(width: 550)
                 .task {
+                    // Invalidate cached details/IPs whenever the connection changes.
+                    // `.dropFirst()` skips the value $netStats replays to a new
+                    // subscriber so app launch doesn't trigger a pointless flush.
+                    // Both observe calls are idempotent, so re-running .task on each
+                    // popover appearance re-subscribes only once.
+                    // Note: the manual refresh button restarts NWPathMonitor and
+                    // re-publishes, so it additionally triggers one flush+refetch here
+                    // — harmless.
+                    connectionDetailsManager.observeConnectionChanges(
+                        netStatsManager.$netStats.dropFirst().eraseToAnyPublisher()
+                    )
+                    netDetailsManager.observeConnectionChanges(
+                        netStatsManager.$netStats.dropFirst().eraseToAnyPublisher()
+                    )
                     await netDetailsManager.getAddresses()
                 }
                 .environmentObject(settings)

--- a/QuickNetStats/QuickNetStatsApp.swift
+++ b/QuickNetStats/QuickNetStatsApp.swift
@@ -13,6 +13,7 @@ struct QuickNetStatsApp: App {
     
     @StateObject var netStatsManager: NetworkStatsManager = NetworkStatsManager()
     @StateObject var netDetailsManager: NetworkDetailsManager = NetworkDetailsManager()
+    @StateObject var connectionDetailsManager: ConnectionDetailsManager = ConnectionDetailsManager()
     @StateObject var settings: Settings = Settings()
     
     let notificationDelegate = NotificationDelegate()
@@ -26,7 +27,8 @@ struct QuickNetStatsApp: App {
             content: {
                 ContentView(
                     netStatsManager: netStatsManager,
-                    netDetailsManager: netDetailsManager
+                    netDetailsManager: netDetailsManager,
+                    connectionDetailsManager: connectionDetailsManager
                 )
                 .padding()
                 .frame(width: 550)

--- a/QuickNetStats/Views/Camponents/DetailGroupView.swift
+++ b/QuickNetStats/Views/Camponents/DetailGroupView.swift
@@ -1,0 +1,84 @@
+//
+//  DetailGroupView.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import SwiftUI
+
+/// A titled two-column grid of label–value rows for one connection-details group.
+/// Each value is a plain button that copies its raw string to the clipboard.
+/// Renders nothing when `rows` is empty.
+struct DetailGroupView: View {
+
+    let title: String
+    let rows: [DetailRow]
+
+    var body: some View {
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                detailsTitle
+                
+                Grid(alignment: .leading, horizontalSpacing: 20, verticalSpacing: 4) {
+                    ForEach(rows) { row in
+                        GridRow {
+                            Text(row.label)
+                                .foregroundStyle(.secondary)
+                                .gridColumnAlignment(.leading)
+
+                            Button {
+                                copy(row.value)
+                            } label: {
+                                Text(row.value)
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Click to copy")
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+    
+    private var detailsTitle: some View {
+        Text(title)
+            .font(.title2)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+    }
+
+    /// Copies the given string to the general pasteboard.
+    private func copy(_ value: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Populated") {
+    DetailGroupView(title: "Interface", rows: ConnectionDetails.mockWifi.interfaceRows)
+        .padding()
+        .frame(width: 300)
+}
+
+#Preview("Empty (renders nothing)") {
+    DetailGroupView(title: "Interface", rows: [])
+        .padding()
+        .frame(width: 300)
+}
+
+#Preview("Long value truncates") {
+    DetailGroupView(
+        title: "Addressing",
+        rows: [DetailRow(label: "IPv6 (local)", value: "2a00:1450:4009:82b:0000:0000:0000:200e")]
+    )
+    .padding()
+    .frame(width: 300)
+}

--- a/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
+++ b/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
@@ -39,6 +39,11 @@ struct LiveStatsSectionView: View {
             Grid(alignment: .leading, horizontalSpacing: 20, verticalSpacing: 4) {
                 liveRow("Download", stats?.downloadText)
                 liveRow("Upload", stats?.uploadText)
+                // Packet/error/drop counters are interface-agnostic, like throughput.
+                liveRow("Packets ↓", stats?.downloadPacketsText)
+                liveRow("Packets ↑", stats?.uploadPacketsText)
+                liveRow("Errors", stats?.errorsText)
+                liveRow("Drops", stats?.dropsText)
 
                 if showsWifiRows {
                     liveRow("RSSI", stats?.rssiText)

--- a/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
+++ b/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
@@ -1,0 +1,98 @@
+//
+//  LiveStatsSectionView.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import SwiftUI
+
+/// The always-last "Live" section of the connection-details dropdown. Idle it
+/// shows grayed titles with "—" placeholders; toggled on it shows live values.
+/// The toggle is delegated to the owner via `onToggle` so all polling lives in
+/// the manager. Live rows are plain text (values churn every second, not copied).
+struct LiveStatsSectionView: View {
+
+    let isLive: Bool
+    let showsWifiRows: Bool
+    let stats: LiveConnectionStats?
+    let onToggle: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Live Stats")
+                    .foregroundStyle(isLive ? .secondary : .tertiary)
+
+                Spacer()
+
+                Button(action: onToggle) {
+                    Label(isLive ? "Stop Monitoring" : "Start Monitoring", systemImage: isLive ? "stop.fill" : "play.fill")
+                        .font(.headline)
+                }
+                .buttonStyle(.plain)
+                .focusable(false)
+                .help(isLive ? "Stop monitoring live metrics" : "Start monitoring live metrics")
+            }
+            .font(.title2)
+
+            Grid(alignment: .leading, horizontalSpacing: 20, verticalSpacing: 4) {
+                liveRow("Download", stats?.downloadText)
+                liveRow("Upload", stats?.uploadText)
+
+                if showsWifiRows {
+                    liveRow("RSSI", stats?.rssiText)
+                    liveRow("Noise", stats?.noiseText)
+                    liveRow("SNR", stats?.snrText)
+                    liveRow("Tx rate", stats?.txRateText)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One label–value grid row. Idle: both cells grayed with a "—" value.
+    /// Live: secondary label, primary value; a momentarily missing value stays "—".
+    @ViewBuilder
+    private func liveRow(_ label: String, _ value: String?) -> some View {
+        GridRow {
+            Text(label)
+                .foregroundStyle(isLive ? .secondary : .tertiary)
+                .gridColumnAlignment(.leading)
+
+            Text(isLive ? (value ?? "—") : "—")
+                .monospacedDigit()
+                .foregroundStyle(isLive ? .primary : .tertiary)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Idle Wi-Fi") {
+    LiveStatsSectionView(isLive: false, showsWifiRows: true, stats: nil, onToggle: {})
+        .padding()
+        .frame(width: 300)
+}
+
+#Preview("Live Wi-Fi") {
+    LiveStatsSectionView(
+        isLive: true,
+        showsWifiRows: true,
+        stats: .mockLiveWifi,
+        onToggle: {}
+    )
+    .padding()
+    .frame(width: 300)
+}
+
+#Preview("Live Wired") {
+    LiveStatsSectionView(
+        isLive: true,
+        showsWifiRows: false,
+        stats: .mockLiveWired,
+        onToggle: {}
+    )
+    .padding()
+    .frame(width: 300)
+}

--- a/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
+++ b/QuickNetStats/Views/Camponents/LiveStatsSectionView.swift
@@ -16,6 +16,10 @@ struct LiveStatsSectionView: View {
     let isLive: Bool
     let showsWifiRows: Bool
     let stats: LiveConnectionStats?
+    /// Unit family for the Download/Upload throughput rows.
+    let liveUnit: RateUnit
+    /// Unit family for the Wi-Fi Tx-rate row.
+    let wifiRateUnit: RateUnit
     let onToggle: () -> Void
 
     var body: some View {
@@ -37,8 +41,8 @@ struct LiveStatsSectionView: View {
             .font(.title2)
 
             Grid(alignment: .leading, horizontalSpacing: 20, verticalSpacing: 4) {
-                liveRow("Download", stats?.downloadText)
-                liveRow("Upload", stats?.uploadText)
+                liveRow("Download", stats?.downloadText(in: liveUnit))
+                liveRow("Upload", stats?.uploadText(in: liveUnit))
                 // Packet/error/drop counters are interface-agnostic, like throughput.
                 liveRow("Packets ↓", stats?.downloadPacketsText)
                 liveRow("Packets ↑", stats?.uploadPacketsText)
@@ -49,7 +53,7 @@ struct LiveStatsSectionView: View {
                     liveRow("RSSI", stats?.rssiText)
                     liveRow("Noise", stats?.noiseText)
                     liveRow("SNR", stats?.snrText)
-                    liveRow("Tx rate", stats?.txRateText)
+                    liveRow("Tx rate", stats?.txRateText(in: wifiRateUnit))
                 }
             }
         }
@@ -75,9 +79,16 @@ struct LiveStatsSectionView: View {
 // MARK: - Previews
 
 #Preview("Idle Wi-Fi") {
-    LiveStatsSectionView(isLive: false, showsWifiRows: true, stats: nil, onToggle: {})
-        .padding()
-        .frame(width: 300)
+    LiveStatsSectionView(
+        isLive: false,
+        showsWifiRows: true,
+        stats: nil,
+        liveUnit: .bytesPerSecond,
+        wifiRateUnit: .bitsPerSecond,
+        onToggle: {}
+    )
+    .padding()
+    .frame(width: 300)
 }
 
 #Preview("Live Wi-Fi") {
@@ -85,6 +96,8 @@ struct LiveStatsSectionView: View {
         isLive: true,
         showsWifiRows: true,
         stats: .mockLiveWifi,
+        liveUnit: .bytesPerSecond,
+        wifiRateUnit: .bitsPerSecond,
         onToggle: {}
     )
     .padding()
@@ -96,6 +109,8 @@ struct LiveStatsSectionView: View {
         isLive: true,
         showsWifiRows: false,
         stats: .mockLiveWired,
+        liveUnit: .bytesPerSecond,
+        wifiRateUnit: .bitsPerSecond,
         onToggle: {}
     )
     .padding()

--- a/QuickNetStats/Views/ContentView.swift
+++ b/QuickNetStats/Views/ContentView.swift
@@ -16,7 +16,8 @@ struct ContentView: View {
     @EnvironmentObject var settings: Settings
     
     @Environment(\.openWindow) var openWindow
-    
+    @Environment(\.dismiss) var dismiss
+
     var body: some View {
         VStack(spacing: 0){
             NetStatsView(
@@ -46,6 +47,7 @@ struct ContentView: View {
             
             Button {
                 openWindow(id: "settings-window")
+                dismiss()
             } label: {
                 FooterButtonLabelView(labelText: "Settings", systemName: "gear")
             }

--- a/QuickNetStats/Views/ContentView.swift
+++ b/QuickNetStats/Views/ContentView.swift
@@ -18,6 +18,10 @@ struct ContentView: View {
     @Environment(\.openWindow) var openWindow
     @Environment(\.dismiss) var dismiss
 
+    /// Measured total popover height, passed down so the Connection Details cap
+    /// can budget from the real chrome instead of a constant.
+    @State private var popoverHeight: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0){
             NetStatsView(
@@ -25,17 +29,24 @@ struct ContentView: View {
                 privateIP: netDetailsManager.privateIP,
                 publicIP: netDetailsManager.publicIP,
                 ssid: netDetailsManager.ssid,
-                connectionDetailsManager: connectionDetailsManager
+                connectionDetailsManager: connectionDetailsManager,
+                popoverHeight: popoverHeight
             )
-            
+
             Divider()
-            
+
             footerButtonsSection
+        }
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            let rounded = height.rounded()
+            if popoverHeight != rounded { popoverHeight = rounded }
         }
         .overlay(alignment: .topTrailing) {
             headerButtonsSection
         }
-        
+
     }
     
     var footerButtonsSection: some View {

--- a/QuickNetStats/Views/ContentView.swift
+++ b/QuickNetStats/Views/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
                 netStats: netStatsManager.netStats,
                 privateIP: netDetailsManager.privateIP,
                 publicIP: netDetailsManager.publicIP,
+                ssid: netDetailsManager.ssid,
                 connectionDetailsManager: connectionDetailsManager
             )
             

--- a/QuickNetStats/Views/ContentView.swift
+++ b/QuickNetStats/Views/ContentView.swift
@@ -11,7 +11,8 @@ struct ContentView: View {
     
     @ObservedObject var netStatsManager: NetworkStatsManager
     @ObservedObject var netDetailsManager: NetworkDetailsManager
-    
+    @ObservedObject var connectionDetailsManager: ConnectionDetailsManager
+
     @EnvironmentObject var settings: Settings
     
     @Environment(\.openWindow) var openWindow
@@ -21,7 +22,8 @@ struct ContentView: View {
             NetStatsView(
                 netStats: netStatsManager.netStats,
                 privateIP: netDetailsManager.privateIP,
-                publicIP: netDetailsManager.publicIP
+                publicIP: netDetailsManager.publicIP,
+                connectionDetailsManager: connectionDetailsManager
             )
             
             Divider()
@@ -59,6 +61,7 @@ struct ContentView: View {
             Task {
                 netStatsManager.refresh()
                 await netDetailsManager.deleteAndGetAddresses()
+                await connectionDetailsManager.refresh()
             }
         } label: {
             Image(systemName: "arrow.trianglehead.counterclockwise")
@@ -82,7 +85,11 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(netStatsManager: NetworkStatsManager(), netDetailsManager: NetworkDetailsManager())
-        .environmentObject(Settings())
-        .frame(height: 350)
+    ContentView(
+        netStatsManager: NetworkStatsManager(),
+        netDetailsManager: NetworkDetailsManager(),
+        connectionDetailsManager: ConnectionDetailsManager()
+    )
+    .environmentObject(Settings())
+    .frame(height: 350)
 }

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -17,23 +17,53 @@ struct ConnectionDetailsView: View {
     @EnvironmentObject var settings: Settings
     @State private var isExpanded = false
 
-    /// Fallback cap used when no screen height is available (e.g. `NSScreen.main` is nil).
-    private static let fallbackMaxDetailsHeight: CGFloat = 600
-    @State private var detailsContentHeight: CGFloat = .infinity
+    var popoverHeight: CGFloat = 0
 
-    /// The scroll-view height cap for the expanded details, capped at 3/4 of the
-    /// screen the app is currently viewed on. Read per body evaluation via
-    /// `NSScreen.main` (the screen containing the key window — the MenuBarExtra
-    /// panel is key while the popover is open), so reopening the popover on a
-    /// different display picks up that screen's height.
-    private var maxDetailsHeight: CGFloat {
-        Self.maxDetailsHeight(forScreenHeight: NSScreen.main?.frame.height)
+    private static let fallbackMaxDetailsHeight: CGFloat = 600
+    
+    /// Gap kept between the popover and the menu bar when budgeting by visible height.
+    private static let detailsMargin: CGFloat = 16
+    
+    private static let minimumDetailsHeight: CGFloat = 100
+
+    @State private var detailsContentHeight: CGFloat = .infinity
+    
+    /// Rendered height of the details scroll view itself. Subtracted from
+    /// ``popoverHeight`` to derive the popover chrome (icon block, IP buttons,
+    /// exception text, buttons, footer, paddings).
+    @State private var scrollRenderedHeight: CGFloat = 0
+
+    private var chromeHeight: CGFloat? {
+        guard popoverHeight > 0, scrollRenderedHeight > 0 else { return nil }
+        return (popoverHeight - scrollRenderedHeight).rounded()
     }
 
-    /// Returns 3/4 of `screenHeight`, or ``fallbackMaxDetailsHeight`` when it is nil.
-    static func maxDetailsHeight(forScreenHeight screenHeight: CGFloat?) -> CGFloat {
+    /// The scroll-view height cap for the expanded details. Read per body
+    /// evaluation via `NSScreen.main` (the screen containing the key window — the
+    /// MenuBarExtra panel is key while the popover is open), so reopening the
+    /// popover on a different display picks up that screen's metrics.
+    private var maxDetailsHeight: CGFloat {
+        Self.maxDetailsHeight(
+            screenHeight: NSScreen.main?.frame.height,
+            visibleHeight: NSScreen.main?.visibleFrame.height,
+            chromeHeight: chromeHeight
+        )
+    }
+
+    /// Bounds the details cap by, in order of precedence.
+    /// Returns the smaller of the applicable bounds.
+    static func maxDetailsHeight(
+        screenHeight: CGFloat?,
+        visibleHeight: CGFloat?,
+        chromeHeight: CGFloat?
+    ) -> CGFloat {
         guard let screenHeight else { return fallbackMaxDetailsHeight }
-        return screenHeight * 0.75
+        
+        let userBound = screenHeight * 0.75
+        guard let visibleHeight, let chromeHeight, chromeHeight > 0 else { return userBound }
+        
+        let fitBound = max(minimumDetailsHeight, visibleHeight - chromeHeight - detailsMargin)
+        return min(userBound, fitBound)
     }
 
     var body: some View {
@@ -80,6 +110,12 @@ struct ConnectionDetailsView: View {
                     }
                     .scrollIndicators(.hidden)
                     .frame(height: min(detailsContentHeight, maxDetailsHeight))
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.height
+                    } action: { height in
+                        let rounded = height.rounded()
+                        if scrollRenderedHeight != rounded { scrollRenderedHeight = rounded }
+                    }
                 } else {
                     ProgressView()
                         .controlSize(.small)

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -16,38 +16,53 @@ struct ConnectionDetailsView: View {
     @EnvironmentObject var settings: Settings
     @State private var isExpanded = false
 
+    private static let maxDetailsHeight: CGFloat = 600
+    @State private var detailsContentHeight: CGFloat = .infinity
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             connectionDetailsButton
             
             if isExpanded {
                 if let details = manager.details {
-                    DetailGroupView(
-                        title: "Interface",
-                        rows: details.interfaceRows(
-                            rateUnit: settings.interfaceRateUnit,
-                            includeBSSID: settings.showNetworkNames
-                        )
-                    )
-                    Divider()
-                    DetailGroupView(title: "Addressing", rows: details.addressingRows)
-                    Divider()
-                    DetailGroupView(title: "DNS & DHCP", rows: details.dnsDhcpRows)
-                    if !details.proxyRows.isEmpty {
-                        Divider()
-                        DetailGroupView(title: "Proxy", rows: details.proxyRows)
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 8) {
+                            DetailGroupView(
+                                title: "Interface",
+                                rows: details.interfaceRows(
+                                    rateUnit: settings.interfaceRateUnit,
+                                    includeBSSID: settings.showNetworkNames
+                                )
+                            )
+                            Divider()
+                            DetailGroupView(title: "Addressing", rows: details.addressingRows)
+                            Divider()
+                            DetailGroupView(title: "DNS & DHCP", rows: details.dnsDhcpRows)
+                            if !details.proxyRows.isEmpty {
+                                Divider()
+                                DetailGroupView(title: "Proxy", rows: details.proxyRows)
+                            }
+                            Divider()
+                            DetailGroupView(title: "Wi-Fi", rows: details.wifiRows)
+                            Divider()
+                            LiveStatsSectionView(
+                                isLive: manager.isLive,
+                                showsWifiRows: details.wifi != nil,
+                                stats: manager.liveStats,
+                                liveUnit: settings.liveRateUnit,
+                                wifiRateUnit: settings.wifiRateUnit,
+                                onToggle: { manager.isLive ? manager.stopLive() : manager.startLive() }
+                            )
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .onGeometryChange(for: CGFloat.self) { proxy in
+                            proxy.size.height
+                        } action: { height in
+                            detailsContentHeight = height
+                        }
                     }
-                    Divider()
-                    DetailGroupView(title: "Wi-Fi", rows: details.wifiRows)
-                    Divider()
-                    LiveStatsSectionView(
-                        isLive: manager.isLive,
-                        showsWifiRows: details.wifi != nil,
-                        stats: manager.liveStats,
-                        liveUnit: settings.liveRateUnit,
-                        wifiRateUnit: settings.wifiRateUnit,
-                        onToggle: { manager.isLive ? manager.stopLive() : manager.startLive() }
-                    )
+                    .scrollIndicators(.hidden)
+                    .frame(height: min(detailsContentHeight, Self.maxDetailsHeight))
                 } else {
                     ProgressView()
                         .controlSize(.small)

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -1,0 +1,115 @@
+//
+//  ConnectionDetailsView.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-04.
+//
+
+import SwiftUI
+
+/// The collapsible "Connection Details" dropdown shown below the IP buttons.
+/// Fetches on first expand, stops live polling on collapse and on popover close.
+/// Expansion state is intentionally not persisted: a fresh popover is collapsed.
+struct ConnectionDetailsView: View {
+
+    @ObservedObject var manager: ConnectionDetailsManager
+    @EnvironmentObject var settings: Settings
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            connectionDetailsButton
+            
+            if isExpanded {
+                if let details = manager.details {
+                    DetailGroupView(title: "Interface", rows: details.interfaceRows)
+                    Divider()
+                    DetailGroupView(title: "Addressing", rows: details.addressingRows)
+                    Divider()
+                    DetailGroupView(title: "DNS & DHCP", rows: details.dnsDhcpRows)
+                    Divider()
+                    DetailGroupView(title: "Wi-Fi", rows: details.wifiRows)
+                    Divider()
+                    LiveStatsSectionView(
+                        isLive: manager.isLive,
+                        showsWifiRows: details.wifi != nil,
+                        stats: manager.liveStats,
+                        onToggle: { manager.isLive ? manager.stopLive() : manager.startLive() }
+                    )
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .animation(settings.useAnimations ? .default : nil, value: isExpanded)
+        .task(id: isExpanded) {
+            if isExpanded && manager.details == nil {
+                await manager.fetchDetails()
+            }
+        }
+        .onDisappear {
+            manager.stopLive()
+        }
+    }
+    
+    var connectionDetailsButton: some View {
+        Button {
+            isExpanded.toggle()
+            if !isExpanded { manager.stopLive() }
+        } label: {
+            connectionDetailsLabel
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+    }
+    
+    var connectionDetailsLabel: some View {
+        HStack(spacing: 8) {
+            Text("Connection Details")
+            Image(systemName: "chevron.right")
+                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+        }
+        .font(.callout)
+        .foregroundStyle(.secondary)
+
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Wi-Fi (expanded)") {
+    ConnectionDetailsView(manager: .preview(details: .mockWifi))
+        .padding()
+        .frame(width: 550, height: 1000)
+        .environmentObject(Settings())
+}
+
+#Preview("Ethernet (expanded)") {
+    ConnectionDetailsView(manager: .preview(details: .mockEthernet))
+        .padding()
+        .frame(width: 550, height: 1000)
+        .environmentObject(Settings())
+}
+
+#Preview("VPN (expanded)") {
+    ConnectionDetailsView(manager: .preview(details: .mockVPN))
+        .padding()
+        .frame(width: 550, height: 1000)
+        .environmentObject(Settings())
+}
+
+#Preview("Loading") {
+    ConnectionDetailsView(manager: .preview(details: nil))
+        .padding()
+        .frame(width: 550, height: 1000)
+        .environmentObject(Settings())
+}
+
+#Preview("Live") {
+    ConnectionDetailsView(manager: .preview(details: .mockWifi, isLive: true, liveStats: .mockLiveWifi))
+        .padding()
+        .frame(width: 550, height: 1000)
+        .environmentObject(Settings())
+}

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -22,7 +22,7 @@ struct ConnectionDetailsView: View {
             
             if isExpanded {
                 if let details = manager.details {
-                    DetailGroupView(title: "Interface", rows: details.interfaceRows)
+                    DetailGroupView(title: "Interface", rows: details.interfaceRows(rateUnit: settings.interfaceRateUnit))
                     Divider()
                     DetailGroupView(title: "Addressing", rows: details.addressingRows)
                     Divider()
@@ -38,6 +38,8 @@ struct ConnectionDetailsView: View {
                         isLive: manager.isLive,
                         showsWifiRows: details.wifi != nil,
                         stats: manager.liveStats,
+                        liveUnit: settings.liveRateUnit,
+                        wifiRateUnit: settings.wifiRateUnit,
                         onToggle: { manager.isLive ? manager.stopLive() : manager.startLive() }
                     )
                 } else {
@@ -51,6 +53,11 @@ struct ConnectionDetailsView: View {
         .task(id: isExpanded) {
             if isExpanded && manager.details == nil {
                 await manager.fetchDetails()
+            }
+            // Auto-start Live Stats on expand when the user opted in; startLive()
+            // itself no-ops if polling is already running.
+            if isExpanded && settings.startLiveMonitoringOnOpen {
+                manager.startLive()
             }
         }
         .onDisappear {

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -22,7 +22,13 @@ struct ConnectionDetailsView: View {
             
             if isExpanded {
                 if let details = manager.details {
-                    DetailGroupView(title: "Interface", rows: details.interfaceRows(rateUnit: settings.interfaceRateUnit))
+                    DetailGroupView(
+                        title: "Interface",
+                        rows: details.interfaceRows(
+                            rateUnit: settings.interfaceRateUnit,
+                            includeBSSID: settings.showNetworkNames
+                        )
+                    )
                     Divider()
                     DetailGroupView(title: "Addressing", rows: details.addressingRows)
                     Divider()

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -27,6 +27,10 @@ struct ConnectionDetailsView: View {
                     DetailGroupView(title: "Addressing", rows: details.addressingRows)
                     Divider()
                     DetailGroupView(title: "DNS & DHCP", rows: details.dnsDhcpRows)
+                    if !details.proxyRows.isEmpty {
+                        Divider()
+                        DetailGroupView(title: "Proxy", rows: details.proxyRows)
+                    }
                     Divider()
                     DetailGroupView(title: "Wi-Fi", rows: details.wifiRows)
                     Divider()

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AppKit
 
 /// The collapsible "Connection Details" dropdown shown below the IP buttons.
 /// Fetches on first expand, stops live polling on collapse and on popover close.
@@ -16,8 +17,24 @@ struct ConnectionDetailsView: View {
     @EnvironmentObject var settings: Settings
     @State private var isExpanded = false
 
-    private static let maxDetailsHeight: CGFloat = 600
+    /// Fallback cap used when no screen height is available (e.g. `NSScreen.main` is nil).
+    private static let fallbackMaxDetailsHeight: CGFloat = 600
     @State private var detailsContentHeight: CGFloat = .infinity
+
+    /// The scroll-view height cap for the expanded details, capped at 3/4 of the
+    /// screen the app is currently viewed on. Read per body evaluation via
+    /// `NSScreen.main` (the screen containing the key window — the MenuBarExtra
+    /// panel is key while the popover is open), so reopening the popover on a
+    /// different display picks up that screen's height.
+    private var maxDetailsHeight: CGFloat {
+        Self.maxDetailsHeight(forScreenHeight: NSScreen.main?.frame.height)
+    }
+
+    /// Returns 3/4 of `screenHeight`, or ``fallbackMaxDetailsHeight`` when it is nil.
+    static func maxDetailsHeight(forScreenHeight screenHeight: CGFloat?) -> CGFloat {
+        guard let screenHeight else { return fallbackMaxDetailsHeight }
+        return screenHeight * 0.75
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -62,7 +79,7 @@ struct ConnectionDetailsView: View {
                         }
                     }
                     .scrollIndicators(.hidden)
-                    .frame(height: min(detailsContentHeight, Self.maxDetailsHeight))
+                    .frame(height: min(detailsContentHeight, maxDetailsHeight))
                 } else {
                     ProgressView()
                         .controlSize(.small)

--- a/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
+++ b/QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// The collapsible "Connection Details" dropdown shown below the IP buttons.
 /// Fetches on first expand, stops live polling on collapse and on popover close.
-/// Expansion state is intentionally not persisted: a fresh popover is collapsed.
+/// On popover close the dropdown collapses, unless `Settings.keepDetailsExpanded` is enabled.
 struct ConnectionDetailsView: View {
 
     @ObservedObject var manager: ConnectionDetailsManager
@@ -51,6 +51,9 @@ struct ConnectionDetailsView: View {
         }
         .onDisappear {
             manager.stopLive()
+            if !settings.keepDetailsExpanded {
+                isExpanded = false
+            }
         }
     }
     

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -69,8 +69,6 @@ struct NetStatsView: View {
             if vm.netStats.isConnected {
                 ConnectionDetailsView(manager: connectionDetailsManager)
             }
-
-
         }
         .padding()
     }

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -63,12 +63,13 @@ struct NetStatsView: View {
             }
             
             ipButtonsSection
+            
+            exceptionDescriptionSection
 
             if vm.netStats.isConnected {
                 ConnectionDetailsView(manager: connectionDetailsManager)
             }
 
-            exceptionDescriptionSection
 
         }
         .padding()
@@ -92,6 +93,8 @@ struct NetStatsView: View {
                 if vm.netStats.isConstrained {
                     Text("**Low Data Mode** is enabled for this network.")
                 }
+                
+                Divider()
             }
         }
         .foregroundStyle(.secondary)

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -17,16 +17,21 @@ struct NetStatsView: View {
     @ObservedObject var connectionDetailsManager: ConnectionDetailsManager
 
     var vm: NetStatsViewModel
+    /// Total popover height, forwarded to ``ConnectionDetailsView`` so its cap can
+    /// budget from the real chrome. Defaults to 0 so previews stay compiling.
+    var popoverHeight: CGFloat = 0
 
     init(
         netStats: NetworkStats,
         privateIP: String?,
         publicIP: String?,
         ssid: String? = nil,
-        connectionDetailsManager: ConnectionDetailsManager
+        connectionDetailsManager: ConnectionDetailsManager,
+        popoverHeight: CGFloat = 0
     ) {
         self.vm = NetStatsViewModel(netStats: netStats, privateIP: privateIP, publicIP: publicIP, ssid: ssid)
         self.connectionDetailsManager = connectionDetailsManager
+        self.popoverHeight = popoverHeight
     }
 
     /// Icon tint used when colorful mode is off: readable in both appearances.
@@ -67,7 +72,7 @@ struct NetStatsView: View {
             exceptionDescriptionSection
 
             if vm.netStats.isConnected {
-                ConnectionDetailsView(manager: connectionDetailsManager)
+                ConnectionDetailsView(manager: connectionDetailsManager, popoverHeight: popoverHeight)
             }
         }
         .padding()

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -22,9 +22,10 @@ struct NetStatsView: View {
         netStats: NetworkStats,
         privateIP: String?,
         publicIP: String?,
+        ssid: String? = nil,
         connectionDetailsManager: ConnectionDetailsManager
     ) {
-        self.vm = NetStatsViewModel(netStats: netStats, privateIP: privateIP, publicIP: publicIP)
+        self.vm = NetStatsViewModel(netStats: netStats, privateIP: privateIP, publicIP: publicIP, ssid: ssid)
         self.connectionDetailsManager = connectionDetailsManager
     }
 
@@ -36,11 +37,21 @@ struct NetStatsView: View {
     var body: some View {
         VStack(spacing: 16) {
             HStack (alignment: .center, spacing: 40){
-                NetworkInterfaceView(
-                    netInterfaceType: vm.netStats.interfaceType,
-                    isAvailable: vm.netStats.isConnected,
-                    linkQualityColor: settings.isColorful ? vm.linkQualityColor : monochromeColor
-                )
+                VStack(spacing: 6) {
+                    NetworkInterfaceView(
+                        netInterfaceType: vm.netStats.interfaceType,
+                        isAvailable: vm.netStats.isConnected,
+                        linkQualityColor: settings.isColorful ? vm.linkQualityColor : monochromeColor
+                    )
+
+                    if settings.showNetworkNames, vm.isWifiConnection, let ssid = vm.ssid {
+                        Text(ssid)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.gray)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
                 .frame(height: 80)
 
                 if let linkQuality = vm.netStats.linkQuality {
@@ -118,6 +129,7 @@ struct NetStatsView: View {
         netStats: NetworkStats.mockGoodWifiConnection,
         privateIP: "10.0.0.32",
         publicIP: "100.10.30.2",
+        ssid: "HomeNet 5GHz",
         connectionDetailsManager: .preview(details: .mockWifi)
     )
         .padding()

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -52,7 +52,7 @@ struct NetStatsView: View {
                             .truncationMode(.middle)
                     }
                 }
-                .frame(height: 80)
+                .frame(height: 90)
 
                 if let linkQuality = vm.netStats.linkQuality {
                     LinkQualityView(

--- a/QuickNetStats/Views/NetStatsView/NetStatsView.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsView.swift
@@ -14,10 +14,18 @@ struct NetStatsView: View {
     @EnvironmentObject var settings: Settings
     @Environment(\.colorScheme) private var colorScheme
 
+    @ObservedObject var connectionDetailsManager: ConnectionDetailsManager
+
     var vm: NetStatsViewModel
 
-    init(netStats: NetworkStats, privateIP: String?, publicIP: String?) {
+    init(
+        netStats: NetworkStats,
+        privateIP: String?,
+        publicIP: String?,
+        connectionDetailsManager: ConnectionDetailsManager
+    ) {
         self.vm = NetStatsViewModel(netStats: netStats, privateIP: privateIP, publicIP: publicIP)
+        self.connectionDetailsManager = connectionDetailsManager
     }
 
     /// Icon tint used when colorful mode is off: readable in both appearances.
@@ -45,8 +53,12 @@ struct NetStatsView: View {
             
             ipButtonsSection
 
+            if vm.netStats.isConnected {
+                ConnectionDetailsView(manager: connectionDetailsManager)
+            }
+
             exceptionDescriptionSection
-                        
+
         }
         .padding()
     }
@@ -105,7 +117,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockGoodWifiConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockWifi)
     )
         .padding()
         .frame(width: 550)
@@ -116,7 +129,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockModerateWifiConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockWifi)
     )
     .padding()
     .frame(width: 550)
@@ -127,7 +141,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockBadWifiConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockWifi)
     )
     .padding()
     .frame(width: 550)
@@ -138,7 +153,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockGoodEthConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockEthernet)
     )
     .padding()
     .frame(width: 550)
@@ -149,7 +165,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockConstrainedWifiConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockWifi)
     )
     .padding()
     .frame(width: 550)
@@ -160,7 +177,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockConstrainedExpensiveCellConnection,
         privateIP: "10.0.0.32",
-        publicIP: "100.10.30.2"
+        publicIP: "100.10.30.2",
+        connectionDetailsManager: .preview(details: .mockWifi)
     )
     .padding()
     .frame(width: 550)
@@ -171,7 +189,8 @@ struct NetStatsView: View {
     NetStatsView(
         netStats: NetworkStats.mockDisconnected,
         privateIP: nil,
-        publicIP: nil
+        publicIP: nil,
+        connectionDetailsManager: .preview(details: nil)
     )
     .padding()
     .frame(width: 550)
@@ -183,30 +202,33 @@ struct NetStatsView: View {
         NetStatsView(
             netStats: NetworkStats.mockGoodWifiConnection,
             privateIP: "10.0.0.32",
-            publicIP: "100.10.30.2"
+            publicIP: "100.10.30.2",
+            connectionDetailsManager: .preview(details: .mockWifi)
         )
         .padding()
         .frame(width: 550)
         .environmentObject(Settings())
-        
+
         NetStatsView(
             netStats: NetworkStats.mockModerateWifiConnection,
             privateIP: "10.0.0.32",
-            publicIP: "100.10.30.2"
+            publicIP: "100.10.30.2",
+            connectionDetailsManager: .preview(details: .mockWifi)
         )
         .padding()
         .frame(width: 550)
         .environmentObject(Settings())
-        
+
         NetStatsView(
             netStats: NetworkStats.mockBadWifiConnection,
             privateIP: "10.0.0.32",
-            publicIP: "100.10.30.2"
+            publicIP: "100.10.30.2",
+            connectionDetailsManager: .preview(details: .mockWifi)
         )
         .padding()
         .frame(width: 550)
         .environmentObject(Settings())
-        
+
     }
 }
 
@@ -215,20 +237,22 @@ struct NetStatsView: View {
         NetStatsView(
             netStats: NetworkStats.mockConstrainedWifiConnection,
             privateIP: "10.0.0.32",
-            publicIP: "100.10.30.2"
+            publicIP: "100.10.30.2",
+            connectionDetailsManager: .preview(details: .mockWifi)
         )
         .padding()
         .frame(width: 550)
         .environmentObject(Settings())
-        
+
         NetStatsView(
             netStats: NetworkStats.mockExpensiveCellConnection,
             privateIP: "10.0.0.32",
-            publicIP: "100.10.30.2"
+            publicIP: "100.10.30.2",
+            connectionDetailsManager: .preview(details: .mockEthernet)
         )
         .padding()
         .frame(width: 550)
         .environmentObject(Settings())
-        
+
     }
 }

--- a/QuickNetStats/Views/NetStatsView/NetStatsViewModel.swift
+++ b/QuickNetStats/Views/NetStatsView/NetStatsViewModel.swift
@@ -6,17 +6,25 @@
 //
 
 import SwiftUI
+import Network
 
 class NetStatsViewModel {
     
     var netStats: NetworkStats
     var privateIP: String?
     var publicIP: String?
+    var ssid: String?
 
-    init(netStats: NetworkStats, privateIP: String?, publicIP: String?) {
+    init(netStats: NetworkStats, privateIP: String?, publicIP: String?, ssid: String? = nil) {
         self.netStats = netStats
         self.privateIP = privateIP
         self.publicIP = publicIP
+        self.ssid = ssid
+    }
+
+    /// True when the SSID label is meaningful: the active connection actually rides Wi-Fi.
+    var isWifiConnection: Bool {
+        netStats.interfaceType == .wifi || netStats.connectionTechnology == .wifi
     }
 
     var linkQualityColor: Color {

--- a/QuickNetStats/Views/SettingsView/AboutView.swift
+++ b/QuickNetStats/Views/SettingsView/AboutView.swift
@@ -45,9 +45,21 @@ struct AboutView: View {
                 .font(.largeTitle)
                 .fontWeight(.bold)
             
-            Text(updateManager.getCurrentVersion())
-                .font(.headline)
-                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                Text(updateManager.getCurrentVersion())
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+
+                if updateManager.isBetaBuild {
+                    Text("BETA")
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundStyle(.tint)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.tint.opacity(0.15), in: Capsule())
+                }
+            }
             
             HStack(spacing: 4) {
                 Text("Developed by")

--- a/QuickNetStats/Views/SettingsView/AboutView.swift
+++ b/QuickNetStats/Views/SettingsView/AboutView.swift
@@ -54,7 +54,7 @@ struct AboutView: View {
                     Text("BETA")
                         .font(.caption)
                         .fontWeight(.bold)
-                        .foregroundStyle(.tint)
+                        .foregroundStyle(.orange)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(.tint.opacity(0.15), in: Capsule())

--- a/QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift
+++ b/QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift
@@ -1,0 +1,71 @@
+//
+//  ConnectionDetailsSettingsView.swift
+//  QuickNetStats
+//
+//  Created by Federico Imberti on 2026-07-06.
+//
+
+import SwiftUI
+
+/// Settings page letting the user pick the display unit (bits vs bytes per second)
+/// for each rate-bearing section of the Connection Details dropdown. Defaults equal
+/// each section's native unit, so the dropdown looks identical until changed.
+struct ConnectionDetailsSettingsView: View {
+
+    @ObservedObject var settings: Settings
+
+    var body: some View {
+        Form {
+            Section {
+                unitPicker(
+                    title: "Interface",
+                    description: "Link speed",
+                    selection: $settings.interfaceRateUnit
+                )
+
+                unitPicker(
+                    title: "Wi-Fi",
+                    description: "Tx rate",
+                    selection: $settings.wifiRateUnit
+                )
+
+                unitPicker(
+                    title: "Live",
+                    description: "Download and Upload",
+                    selection: $settings.liveRateUnit
+                )
+            } header: {
+                Text("Rate Units")
+            }
+            
+            Section {
+                ToggleView(
+                    title: "Start live monitoring immediately",
+                    variable: $settings.startLiveMonitoringOnOpen,
+                    description: "Start monitoring of Live Stats when 'Connection Details' opens"
+                )
+            } header: {
+                Text("Live Stats")
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+    }
+
+    /// One labeled picker offering every `RateUnit`, tagged so the binding round-trips.
+    private func unitPicker(
+        title: String,
+        description: String,
+        selection: Binding<RateUnit>
+    ) -> some View {
+        PickerView(title: title, selection: selection, description: description) {
+            ForEach(RateUnit.allCases) { unit in
+                Text(unit.displayName).tag(unit)
+            }
+        }
+    }
+}
+
+#Preview {
+    ConnectionDetailsSettingsView(settings: Settings())
+}

--- a/QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift
+++ b/QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift
@@ -14,6 +14,15 @@ struct ConnectionDetailsSettingsView: View {
 
     @ObservedObject var settings: Settings
 
+    /// Page-local owner of the Location Services authorization state, driving the
+    /// opt-in network-names toggle's one-time prompt.
+    @StateObject private var locationPermission = LocationPermissionManager()
+
+    /// Shown right after the user grants the Location Services prompt: CoreWLAN
+    /// only picks up the new permission at launch, so SSID/BSSID stay empty until
+    /// the app restarts.
+    @State private var showRestartAlert = false
+
     var body: some View {
         Form {
             Section {
@@ -47,9 +56,75 @@ struct ConnectionDetailsSettingsView: View {
             } header: {
                 Text("Live Stats")
             }
+
+            Section {
+                ToggleView(
+                    title: "Show network name (SSID) & BSSID",
+                    variable: showNetworkNamesBinding,
+                    description: "Displays the Wi-Fi name in the main window and the BSSID in "
+                        + "'Connection Details'. macOS requires Location Services permission for "
+                        + "these; your location is never collected or stored."
+                )
+
+                if locationPermission.state == .denied {
+                    HStack {
+                        Text("Location access is denied. Allow QuickNetStats under Privacy & Security → Location Services.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Spacer()
+                        Button("Open Settings") { openLocationSettings() }
+                    }
+                }
+            } header: {
+                Text("Network Names")
+            }
         }
         .formStyle(.grouped)
         .padding()
+        .alert("Restart QuickNetStats", isPresented: $showRestartAlert) {
+            Button("Quit Now") { NSApp.terminate(nil) }
+            Button("Later", role: .cancel) { }
+        } message: {
+            Text("macOS applies the Location Services permission when the app starts. "
+                + "Quit and reopen QuickNetStats to see the network name and BSSID.")
+        }
+    }
+
+    /// Bridges the toggle to `Settings.showNetworkNames`, injecting the one-time
+    /// Location Services prompt: while undetermined the toggle stays off and the
+    /// system prompt decides; once authorized it flips freely without re-prompting.
+    private var showNetworkNamesBinding: Binding<Bool> {
+        Binding(
+            get: { settings.showNetworkNames },
+            set: { isOn in
+                guard isOn else {
+                    settings.showNetworkNames = false
+                    return
+                }
+                
+                switch locationPermission.state {
+                case .authorized:
+                    settings.showNetworkNames = true
+                case .notDetermined:
+                    locationPermission.requestAuthorization {
+                        settings.showNetworkNames = true
+                        showRestartAlert = true
+                    }
+                case .denied:
+                    break   // stays off; the caption below offers the recovery path
+                }
+            }
+        )
+    }
+
+    /// Opens System Settings on the Location Services privacy pane (mirrors
+    /// `ContentView.openNetworkSettings()`).
+    private func openLocationSettings() {
+        let urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"
+        if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     /// One labeled picker offering every `RateUnit`, tagged so the binding round-trips.

--- a/QuickNetStats/Views/SettingsView/SettingsView.swift
+++ b/QuickNetStats/Views/SettingsView/SettingsView.swift
@@ -33,6 +33,8 @@ struct SettingsView: View {
                 MenuBarView(settings: settings)
             case .visuals:
                 VisualsView(settings: settings)
+            case .connectionDetails:
+                ConnectionDetailsSettingsView(settings: settings)
             case .notifications:
                 NotificationView(settings: settings)
             case .about:

--- a/QuickNetStats/Views/SettingsView/SettingsView.swift
+++ b/QuickNetStats/Views/SettingsView/SettingsView.swift
@@ -56,7 +56,14 @@ struct SettingsView: View {
         .onAppear {
             // Show the app icon in the dock and bring the settings to the foreground
             NSApp.setActivationPolicy(.regular)
-            NSApp.activate(ignoringOtherApps: true)
+            // Defer activation one runloop turn: closing the MenuBarExtra panel hands focus
+            // back to the previously frontmost app, which would bury this window otherwise
+            DispatchQueue.main.async {
+                NSApp.activate(ignoringOtherApps: true)
+                NSApp.windows
+                    .first { $0.identifier?.rawValue.hasPrefix("settings-window") == true }?
+                    .orderFrontRegardless()
+            }
         }
         .onDisappear {
             // Hide the app icon from the dock

--- a/QuickNetStats/Views/SettingsView/SettingsViewModel.swift
+++ b/QuickNetStats/Views/SettingsView/SettingsViewModel.swift
@@ -12,32 +12,37 @@ import Combine
 class SettingsViewModel: ObservableObject {
         
     enum SettingsPage: String, CaseIterable, Identifiable {
-        case menubar, visuals, notifications, about 
-        
+        case menubar, visuals, connectionDetails, notifications, about
+
         var id: String { self.rawValue }
-        
+
         var title: String {
             switch self {
             case .menubar: return "Menu Bar"
             case .visuals: return "Visuals"
+            case .connectionDetails: return "Connection Details"
             case .about: return "About"
             case .notifications: return "Notifications"
             }
         }
-        
+
         var icon: String {
             switch self {
             case .menubar: return "menubar.rectangle"
             case .visuals: return "accessibility"
+            // "gauge.with.dots.needle.67percent" is SF Symbols 5 (macOS 14+); the
+            // deployment target is macOS 13, so use the always-available fallback.
+            case .connectionDetails: return "speedometer"
             case .about: return "info.circle"
             case .notifications: return "bell.badge"
             }
         }
-        
+
         var color: Color {
             switch self {
             case .menubar: return Color.red
             case .visuals: return Color.blue
+            case .connectionDetails: return Color.orange
             case .about: return Color.gray
             case .notifications: return Color.green
             }

--- a/QuickNetStats/Views/SettingsView/VisualsView.swift
+++ b/QuickNetStats/Views/SettingsView/VisualsView.swift
@@ -24,6 +24,12 @@ struct VisualsView: View {
                     variable: settings.$isColorful,
                     description: "Use colors that change according to the quality of the network"
                 )
+
+                ToggleView(
+                    title: "Keep Details Expanded",
+                    variable: settings.$keepDetailsExpanded,
+                    description: "Keep the Connection Details section expanded after the menu bar closes"
+                )
             } header: {
                 Text("General")
             }

--- a/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
@@ -5,6 +5,7 @@
 
 import Testing
 import Foundation
+import Combine
 @testable import QuickNetStats
 
 // MARK: - Reader test doubles
@@ -393,6 +394,94 @@ struct ConnectionDetailsManagerTests {
         await manager.fetchDetails()
         await manager.refresh()
 
+        #expect(systemConfig.callCount == 2)
+    }
+
+    // MARK: - Connection change
+
+    @Test("connectionChanged is a no-op before the first fetch")
+    func connectionChangedNoOpBeforeFetch() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        manager.connectionChanged()
+
+        // Nothing to invalidate: details stays nil and no refetch is scheduled.
+        #expect(manager.details == nil)
+        #expect(systemConfig.callCount == 0)
+        // Give any erroneously scheduled refetch a chance to run.
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(systemConfig.callCount == 0)
+    }
+
+    @Test("connectionChanged flushes then repopulates details after a fetch")
+    func connectionChangedRefetchesAfterFetch() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+        #expect(manager.details?.addressing.routerAddress == "192.168.1.1")
+
+        // The new interface reports a different router; the change must surface it.
+        var updated = fullSystemConfig
+        updated.routerAddress = "10.0.0.1"
+        systemConfig.result = updated
+        manager.connectionChanged()
+
+        let refetched = await eventually { manager.details?.addressing.routerAddress == "10.0.0.1" }
+        #expect(refetched)
+        #expect(systemConfig.callCount == 2)
+    }
+
+    @Test("observeConnectionChanges refetches on a published change")
+    func observeTriggersRefetch() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+        await manager.fetchDetails()
+
+        let subject = PassthroughSubject<NetworkStats, Never>()
+        manager.observeConnectionChanges(subject.eraseToAnyPublisher())
+        subject.send(.mockGoodEthConnection)
+
+        let refetched = await eventually { systemConfig.callCount == 2 }
+        #expect(refetched)
+    }
+
+    @Test("observeConnectionChanges subscribes once even if called twice")
+    func observeIsIdempotent() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+        await manager.fetchDetails()
+
+        let subject = PassthroughSubject<NetworkStats, Never>()
+        manager.observeConnectionChanges(subject.eraseToAnyPublisher())
+        manager.observeConnectionChanges(subject.eraseToAnyPublisher())
+        subject.send(.mockGoodEthConnection)
+
+        // Exactly one refetch: fetch (1) + one change (2), never (3).
+        let reached = await eventually { systemConfig.callCount == 2 }
+        #expect(reached)
+        try? await Task.sleep(for: .milliseconds(50))
         #expect(systemConfig.callCount == 2)
     }
 

--- a/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
@@ -42,12 +42,17 @@ final class MockInterfaceReader: InterfaceReading {
 
 final class MockWifiReader: WifiReading {
     var result: WifiSnapshot?
+    var currentSSIDResult: String?
     private(set) var callCount = 0
-    init(result: WifiSnapshot?) { self.result = result }
+    init(result: WifiSnapshot?, currentSSID: String? = nil) {
+        self.result = result
+        self.currentSSIDResult = currentSSID
+    }
     func snapshot(for bsdName: String) -> WifiSnapshot? {
         callCount += 1
         return result
     }
+    func currentSSID() -> String? { currentSSIDResult }
 }
 
 final class MockPathReader: PathReading {
@@ -109,7 +114,8 @@ struct ConnectionDetailsManagerTests {
             countryCode: "IT",
             rssiDBm: -52,
             noiseDBm: -95,
-            txRateMbps: 866
+            txRateMbps: 866,
+            bssid: "de:ad:be:ef:00:01"
         )
     }
 
@@ -174,6 +180,20 @@ struct ConnectionDetailsManagerTests {
         #expect(details?.dnsDhcp.dnsServers == ["1.1.1.1"])
         #expect(details?.wifi?.channelNumber == 44)
         #expect(details?.wifi?.security == "WPA3 Personal")
+    }
+
+    @Test("fetch passes the Wi-Fi snapshot's BSSID through to the interface group")
+    func fetchPassesBSSID() async {
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: fullWifi),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.interface.bssid == "de:ad:be:ef:00:01")
     }
 
     @Test("supportsText lists true flags, None when all false, nil when all nil", arguments: [

--- a/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
@@ -1,0 +1,403 @@
+//
+//  ConnectionDetailsManagerTests.swift
+//  QuickNetStatsTests
+//
+
+import Testing
+import Foundation
+@testable import QuickNetStats
+
+// MARK: - Reader test doubles
+
+/// Reference-type reader stubs so tests can observe call counts across `fetch`/`refresh`.
+final class MockSystemConfigReader: SystemConfigReading {
+    var result: SystemConfigSnapshot
+    private(set) var callCount = 0
+    init(result: SystemConfigSnapshot) { self.result = result }
+    func snapshot() -> SystemConfigSnapshot {
+        callCount += 1
+        return result
+    }
+}
+
+final class MockInterfaceReader: InterfaceReading {
+    var result: InterfaceSnapshot
+    /// When > 0, rx/tx byte counters grow by this amount on each call so live
+    /// polling can compute a positive throughput delta (used by Task 7 tests).
+    var incrementPerCall: UInt64 = 0
+    private(set) var callCount = 0
+    init(result: InterfaceSnapshot) { self.result = result }
+    func snapshot(for bsdName: String) -> InterfaceSnapshot {
+        callCount += 1
+        guard incrementPerCall > 0 else { return result }
+        var snapshot = result
+        snapshot.rxBytes = (result.rxBytes ?? 0) + incrementPerCall * UInt64(callCount)
+        snapshot.txBytes = (result.txBytes ?? 0) + incrementPerCall * UInt64(callCount)
+        return snapshot
+    }
+}
+
+final class MockWifiReader: WifiReading {
+    var result: WifiSnapshot?
+    private(set) var callCount = 0
+    init(result: WifiSnapshot?) { self.result = result }
+    func snapshot(for bsdName: String) -> WifiSnapshot? {
+        callCount += 1
+        return result
+    }
+}
+
+@Suite("ConnectionDetailsManager", .serialized)
+struct ConnectionDetailsManagerTests {
+
+    // MARK: - Fixtures
+
+    private var fullSystemConfig: SystemConfigSnapshot {
+        SystemConfigSnapshot(
+            primaryInterface: "en0",
+            primaryInterfaceDisplayName: "Wi-Fi",
+            primaryService: "SERVICE-ID",
+            routerAddress: "192.168.1.1",
+            dnsServers: ["1.1.1.1"],
+            searchDomains: ["home"],
+            subnetMask: "255.255.255.0",
+            dhcpLeaseExpiry: nil,
+            hostname: "mac"
+        )
+    }
+
+    private var fullInterface: InterfaceSnapshot {
+        InterfaceSnapshot(
+            macAddress: "aa:bb:cc:dd:ee:ff",
+            mtu: 1500,
+            ipv6Address: "2a00::1",
+            linkSpeedMbps: 866,
+            rxBytes: 1_000,
+            txBytes: 500
+        )
+    }
+
+    private var fullWifi: WifiSnapshot {
+        WifiSnapshot(
+            channelNumber: 44,
+            band: "5 GHz",
+            channelWidthMHz: 80,
+            phyMode: "802.11ax",
+            security: "WPA3 Personal",
+            countryCode: "IT",
+            rssiDBm: -52,
+            noiseDBm: -95,
+            txRateMbps: 866
+        )
+    }
+
+    /// Builds a session that routes ipify requests through the given handler.
+    private func mockSession(_ handler: @escaping MockURLProtocol.Handler) -> URLSession {
+        MockURLProtocol.requestHandler = handler
+        let config = URLSessionConfiguration.ephemeral
+        let token = UUID().uuidString
+        config.httpAdditionalHeaders = [MockURLProtocol.tokenHeader: token]
+        config.protocolClasses = [MockURLProtocol.self]
+        MockURLProtocol.handlers[token] = MockURLProtocol.requestHandler
+        return URLSession(configuration: config)
+    }
+
+    /// A handler that returns 200 with the given body.
+    private func ok(_ body: String) -> MockURLProtocol.Handler {
+        { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(body.utf8))
+        }
+    }
+
+    // MARK: - Fetch assembly
+
+    @Test("fetch assembles all four groups from the reader stubs")
+    func fetchAssemblesGroups() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let interfaceReader = MockInterfaceReader(result: fullInterface)
+        let wifiReader = MockWifiReader(result: fullWifi)
+
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: interfaceReader,
+            wifiReader: wifiReader,
+            session: mockSession(ok("2a00::1")),
+            pollInterval: 0.05
+        )
+
+        await manager.fetchDetails()
+
+        let details = manager.details
+        #expect(details?.interface.macAddress == "aa:bb:cc:dd:ee:ff")
+        #expect(details?.interface.displayName == "Wi-Fi")
+        #expect(details?.interface.bsdName == "en0")
+        #expect(details?.addressing.routerAddress == "192.168.1.1")
+        #expect(details?.addressing.ipv6Address == "2a00::1")
+        #expect(details?.dnsDhcp.dnsServers == ["1.1.1.1"])
+        #expect(details?.wifi?.channelNumber == 44)
+        #expect(details?.wifi?.security == "WPA3 Personal")
+    }
+
+    @Test("a nil Wi-Fi reader result leaves the Wi-Fi group nil")
+    func nilWifiReaderLeavesGroupNil() async {
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.wifi == nil)
+        #expect(manager.details?.wifiRows.isEmpty == true)
+    }
+
+    // MARK: - Public IPv6
+
+    @Test("a 200 IPv6 body populates publicIPv6")
+    func publicIPv6Populated() async {
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a01:e11::1"))
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.addressing.publicIPv6 == "2a01:e11::1")
+    }
+
+    @Test("a server error leaves publicIPv6 nil")
+    func publicIPv6NilOnServerError() async {
+        let handler: MockURLProtocol.Handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(handler)
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.addressing.publicIPv6 == nil)
+    }
+
+    @Test("a network error leaves publicIPv6 nil")
+    func publicIPv6NilOnNetworkError() async {
+        let handler: MockURLProtocol.Handler = { _ in throw URLError(.notConnectedToInternet) }
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(handler)
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.addressing.publicIPv6 == nil)
+    }
+
+    @Test("a 200 response without a colon is not treated as an IPv6 address")
+    func publicIPv6NilWhenBodyNotV6() async {
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("not-an-address"))
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details?.addressing.publicIPv6 == nil)
+    }
+
+    // MARK: - No primary interface
+
+    @Test("fetch still publishes router/DNS when there is no primary interface")
+    func fetchWithoutPrimaryInterface() async {
+        var systemConfig = fullSystemConfig
+        systemConfig.primaryInterface = nil
+        systemConfig.primaryInterfaceDisplayName = nil
+
+        let interfaceReader = MockInterfaceReader(result: fullInterface)
+        let wifiReader = MockWifiReader(result: fullWifi)
+
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: systemConfig),
+            interfaceReader: interfaceReader,
+            wifiReader: wifiReader,
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+
+        #expect(manager.details != nil)
+        #expect(manager.details?.addressing.routerAddress == "192.168.1.1")
+        #expect(manager.details?.dnsDhcp.dnsServers == ["1.1.1.1"])
+        // With no BSD name the interface/Wi-Fi readers are never consulted.
+        #expect(interfaceReader.callCount == 0)
+        #expect(wifiReader.callCount == 0)
+        #expect(manager.details?.wifi == nil)
+    }
+
+    // MARK: - Refresh
+
+    @Test("refresh is a no-op before the first fetch")
+    func refreshNoOpBeforeFetch() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.refresh()
+
+        #expect(manager.details == nil)
+        #expect(systemConfig.callCount == 0)
+    }
+
+    @Test("refresh re-fetches after the first fetch")
+    func refreshRefetchesAfterFetch() async {
+        let systemConfig = MockSystemConfigReader(result: fullSystemConfig)
+        let manager = ConnectionDetailsManager(
+            systemConfig: systemConfig,
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: nil),
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+        await manager.refresh()
+
+        #expect(systemConfig.callCount == 2)
+    }
+
+    // MARK: - Live polling
+
+    /// Polls `condition` until it is true or the timeout elapses, yielding the
+    /// main actor between checks so the manager's poll loop can advance.
+    @discardableResult
+    private func eventually(
+        timeout: Duration = .seconds(3),
+        _ condition: () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
+
+    /// Builds a manager whose interface reader grows its counters each call so
+    /// the poll loop produces a positive throughput delta.
+    private func liveManager(pollInterval: TimeInterval) -> ConnectionDetailsManager {
+        let interfaceReader = MockInterfaceReader(result: fullInterface)
+        interfaceReader.incrementPerCall = 1_000
+        return ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: interfaceReader,
+            wifiReader: MockWifiReader(result: fullWifi),
+            session: mockSession(ok("2a00::1")),
+            pollInterval: pollInterval
+        )
+    }
+
+    @Test("bytesPerSecond computes deltas and rejects resets and zero elapsed")
+    func bytesPerSecondMath() {
+        #expect(ConnectionDetailsManager.bytesPerSecond(previous: 1_000, current: 3_000, elapsed: 2.0) == 1_000)
+        #expect(ConnectionDetailsManager.bytesPerSecond(previous: 3_000, current: 1_000, elapsed: 2.0) == nil)
+        #expect(ConnectionDetailsManager.bytesPerSecond(previous: 1_000, current: 3_000, elapsed: 0) == nil)
+    }
+
+    @Test("the first tick publishes RF values with no throughput")
+    func firstTickHasRFOnly() async {
+        // An interval far beyond the eventually-timeout guarantees the second tick
+        // can never fire during this test, even under heavy CI load; stopLive()
+        // cancels the sleep so the test still finishes immediately.
+        let manager = liveManager(pollInterval: 60)
+        await manager.fetchDetails()
+        manager.startLive()
+
+        let gotRSSI = await eventually { manager.liveStats?.rssiDBm != nil }
+        #expect(gotRSSI)
+        #expect(manager.liveStats?.rssiDBm == -52)
+        #expect(manager.liveStats?.downloadBytesPerSec == nil)
+
+        manager.stopLive()
+    }
+
+    @Test("throughput appears from the second tick onward")
+    func throughputOnSecondTick() async {
+        let manager = liveManager(pollInterval: 0.05)
+        await manager.fetchDetails()
+        manager.startLive()
+
+        let gotThroughput = await eventually { manager.liveStats?.downloadBytesPerSec != nil }
+        #expect(gotThroughput)
+        #expect(manager.liveStats?.uploadBytesPerSec != nil)
+        #expect(manager.liveStats?.rssiDBm == -52)
+
+        manager.stopLive()
+    }
+
+    @Test("startLive without a prior fetch is safe and publishes nothing")
+    func startLiveWithoutFetchIsSafe() async {
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: fullSystemConfig),
+            interfaceReader: MockInterfaceReader(result: fullInterface),
+            wifiReader: MockWifiReader(result: fullWifi),
+            session: mockSession(ok("2a00::1")),
+            pollInterval: 0.05
+        )
+
+        manager.startLive()
+        #expect(manager.isLive)
+        // tick() guards on details.bsdName, so nothing is published without a fetch.
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(manager.liveStats == nil)
+
+        manager.stopLive()
+        #expect(manager.isLive == false)
+    }
+
+    @Test("stopLive cancels the loop and clears state")
+    func stopLiveClearsState() async {
+        let manager = liveManager(pollInterval: 0.05)
+        await manager.fetchDetails()
+        manager.startLive()
+
+        _ = await eventually { manager.liveStats != nil }
+        #expect(manager.isLive)
+
+        manager.stopLive()
+        #expect(manager.isLive == false)
+        #expect(manager.liveStats == nil)
+    }
+
+    @Test("a second startLive does not stack a second poll loop")
+    func doubleStartDoesNotStack() async {
+        let manager = liveManager(pollInterval: 0.05)
+        await manager.fetchDetails()
+
+        manager.startLive()
+        manager.startLive()   // guarded no-op
+
+        _ = await eventually { manager.liveStats != nil }
+        manager.stopLive()
+
+        #expect(manager.isLive == false)
+        #expect(manager.liveStats == nil)
+        // A leaked/stacked task would keep publishing after stop; it must stay nil.
+        try? await Task.sleep(for: .milliseconds(150))
+        #expect(manager.liveStats == nil)
+    }
+}

--- a/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsManagerTests.swift
@@ -31,8 +31,11 @@ final class MockInterfaceReader: InterfaceReading {
         callCount += 1
         guard incrementPerCall > 0 else { return result }
         var snapshot = result
-        snapshot.rxBytes = (result.rxBytes ?? 0) + incrementPerCall * UInt64(callCount)
-        snapshot.txBytes = (result.txBytes ?? 0) + incrementPerCall * UInt64(callCount)
+        let delta = incrementPerCall * UInt64(callCount)
+        snapshot.rxBytes = (result.rxBytes ?? 0) + delta
+        snapshot.txBytes = (result.txBytes ?? 0) + delta
+        snapshot.rxPackets = (result.rxPackets ?? 0) + delta
+        snapshot.txPackets = (result.txPackets ?? 0) + delta
         return snapshot
     }
 }
@@ -43,6 +46,18 @@ final class MockWifiReader: WifiReading {
     init(result: WifiSnapshot?) { self.result = result }
     func snapshot(for bsdName: String) -> WifiSnapshot? {
         callCount += 1
+        return result
+    }
+}
+
+final class MockPathReader: PathReading {
+    var result: PathSnapshot
+    private(set) var callCount = 0
+    private(set) var receivedExclusion: String?
+    init(result: PathSnapshot = PathSnapshot()) { self.result = result }
+    func snapshot(excluding primaryBSDName: String?) async -> PathSnapshot {
+        callCount += 1
+        receivedExclusion = primaryBSDName
         return result
     }
 }
@@ -73,7 +88,12 @@ struct ConnectionDetailsManagerTests {
             ipv6Address: "2a00::1",
             linkSpeedMbps: 866,
             rxBytes: 1_000,
-            txBytes: 500
+            txBytes: 500,
+            rxPackets: 100,
+            txPackets: 50,
+            inErrors: 0,
+            outErrors: 0,
+            drops: 0
         )
     }
 
@@ -83,6 +103,8 @@ struct ConnectionDetailsManagerTests {
             band: "5 GHz",
             channelWidthMHz: 80,
             phyMode: "802.11ax",
+            interfaceMode: "Station",
+            txPowerMw: 100,
             security: "WPA3 Personal",
             countryCode: "IT",
             rssiDBm: -52,
@@ -108,6 +130,21 @@ struct ConnectionDetailsManagerTests {
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, Data(body.utf8))
         }
+    }
+
+    // MARK: - MockPathReader
+
+    @Test("MockPathReader returns the injected snapshot and records the exclusion")
+    func mockPathReaderReturnsInjected() async {
+        let expected = PathSnapshot(
+            supportsIPv4: true, supportsIPv6: false, supportsDNS: true,
+            otherInterfaces: ["Ethernet (en1)"]
+        )
+        let reader = MockPathReader(result: expected)
+        let got = await reader.snapshot(excluding: "en0")
+        #expect(got == expected)
+        #expect(reader.receivedExclusion == "en0")
+        #expect(reader.callCount == 1)
     }
 
     // MARK: - Fetch assembly
@@ -137,6 +174,65 @@ struct ConnectionDetailsManagerTests {
         #expect(details?.dnsDhcp.dnsServers == ["1.1.1.1"])
         #expect(details?.wifi?.channelNumber == 44)
         #expect(details?.wifi?.security == "WPA3 Personal")
+    }
+
+    @Test("supportsText lists true flags, None when all false, nil when all nil", arguments: [
+        (PathSnapshot(supportsIPv4: true, supportsIPv6: true, supportsDNS: true), Optional("IPv4 · IPv6 · DNS")),
+        (PathSnapshot(supportsIPv4: true, supportsIPv6: false, supportsDNS: true), Optional("IPv4 · DNS")),
+        (PathSnapshot(supportsIPv4: false, supportsIPv6: false, supportsDNS: false), Optional("None")),
+        (PathSnapshot(), nil)
+    ])
+    func supportsTextComposition(path: PathSnapshot, expected: String?) {
+        #expect(ConnectionDetailsManager.supportsText(path) == expected)
+    }
+
+    @Test("fetch assembles the path-derived and extended SC/interface fields")
+    func fetchAssemblesExtendedFields() async {
+        var sc = fullSystemConfig
+        sc.ipv6Router = "fe80::1"
+        sc.ipv4ConfigMethod = "DHCP"
+        sc.computerName = "Mac"
+        sc.dhcpServer = "192.168.1.1"
+        sc.dhcpLeaseStart = Date()
+        sc.proxies = ProxySnapshot(http: "p:80", https: "p:443", socks: nil)
+
+        var iface = fullInterface
+        iface.broadcastAddress = "192.168.1.255"
+        iface.mediaDescription = "1000baseT full-duplex"
+
+        let path = PathSnapshot(
+            supportsIPv4: true, supportsIPv6: false, supportsDNS: true,
+            otherInterfaces: ["Ethernet (en1)"]
+        )
+        let pathReader = MockPathReader(result: path)
+
+        let manager = ConnectionDetailsManager(
+            systemConfig: MockSystemConfigReader(result: sc),
+            interfaceReader: MockInterfaceReader(result: iface),
+            wifiReader: MockWifiReader(result: fullWifi),
+            pathReader: pathReader,
+            session: mockSession(ok("2a00::1"))
+        )
+
+        await manager.fetchDetails()
+
+        let details = manager.details
+        #expect(details?.addressing.ipv6Router == "fe80::1")
+        #expect(details?.addressing.ipv4ConfigMethod == "DHCP")
+        #expect(details?.addressing.computerName == "Mac")
+        #expect(details?.addressing.broadcastAddress == "192.168.1.255")
+        #expect(details?.dnsDhcp.dhcpServer == "192.168.1.1")
+        #expect(details?.dnsDhcp.dhcpLeaseStart != nil)
+        #expect(details?.interface.mediaDescription == "1000baseT full-duplex")
+        #expect(details?.interface.otherInterfaces == ["Ethernet (en1)"])
+        #expect(details?.interface.supports == "IPv4 · DNS")
+        #expect(details?.proxy.httpProxy == "p:80")
+        #expect(details?.proxy.httpsProxy == "p:443")
+        #expect(details?.proxy.socksProxy == nil)
+        #expect(details?.wifi?.mode == "Station")
+        #expect(details?.wifi?.txPowerMw == 100)
+        // The primary BSD name is passed to the path reader for exclusion.
+        #expect(pathReader.receivedExclusion == "en0")
     }
 
     @Test("a nil Wi-Fi reader result leaves the Wi-Fi group nil")
@@ -345,6 +441,38 @@ struct ConnectionDetailsManagerTests {
         #expect(gotThroughput)
         #expect(manager.liveStats?.uploadBytesPerSec != nil)
         #expect(manager.liveStats?.rssiDBm == -52)
+
+        manager.stopLive()
+    }
+
+    @Test("packet/error/drop rates appear from the second tick onward")
+    func countersOnSecondTick() async {
+        let manager = liveManager(pollInterval: 0.05)
+        await manager.fetchDetails()
+        manager.startLive()
+
+        let gotPackets = await eventually { manager.liveStats?.downloadPacketsPerSec != nil }
+        #expect(gotPackets)
+        #expect(manager.liveStats?.uploadPacketsPerSec != nil)
+        // A steady 0-error/0-drop interface still publishes a valid 0/s rate.
+        #expect(manager.liveStats?.errorsPerSec != nil)
+        #expect(manager.liveStats?.dropsPerSec != nil)
+
+        manager.stopLive()
+    }
+
+    @Test("the first tick has nil packet/error/drop rates")
+    func firstTickHasNilCounters() async {
+        let manager = liveManager(pollInterval: 60)
+        await manager.fetchDetails()
+        manager.startLive()
+
+        let gotRSSI = await eventually { manager.liveStats?.rssiDBm != nil }
+        #expect(gotRSSI)
+        #expect(manager.liveStats?.downloadPacketsPerSec == nil)
+        #expect(manager.liveStats?.uploadPacketsPerSec == nil)
+        #expect(manager.liveStats?.errorsPerSec == nil)
+        #expect(manager.liveStats?.dropsPerSec == nil)
 
         manager.stopLive()
     }

--- a/QuickNetStatsTests/ConnectionDetailsTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsTests.swift
@@ -74,6 +74,20 @@ struct ConnectionDetailsTests {
         #expect(value("Link speed", in: details.interfaceRows) == "2.5 Gbps")
     }
 
+    // MARK: - Link speed units
+
+    @Test("Link speed row defaults to bits (native Mbps/Gbps)")
+    func linkSpeedDefaultsToBits() {
+        let details = ConnectionDetails(interface: .init(linkSpeedMbps: 210))
+        #expect(value("Link speed", in: details.interfaceRows(rateUnit: .bitsPerSecond)) == "210 Mbps")
+    }
+
+    @Test("Link speed row converts to bytes when requested")
+    func linkSpeedInBytes() {
+        let details = ConnectionDetails(interface: .init(linkSpeedMbps: 210))
+        #expect(value("Link speed", in: details.interfaceRows(rateUnit: .bytesPerSecond)) == "26.25 MB/s")
+    }
+
     @Test("Media, Supports, and Also available rows follow Link speed in order")
     func interfaceExtraRowsOrder() {
         let details = ConnectionDetails(

--- a/QuickNetStatsTests/ConnectionDetailsTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsTests.swift
@@ -1,0 +1,191 @@
+//
+//  ConnectionDetailsTests.swift
+//  QuickNetStatsTests
+//
+
+import Testing
+import Foundation
+@testable import QuickNetStats
+
+@Suite("ConnectionDetails")
+struct ConnectionDetailsTests {
+
+    /// Returns the value of the row with the given label, or nil if absent.
+    private func value(_ label: String, in rows: [DetailRow]) -> String? {
+        rows.first { $0.label == label }?.value
+    }
+
+    // MARK: - Interface group
+
+    @Test("An empty interface produces no rows")
+    func emptyInterfaceHasNoRows() {
+        let details = ConnectionDetails(interface: .init())
+        #expect(details.interfaceRows.isEmpty)
+    }
+
+    @Test("Name row composes displayName and bsdName")
+    func nameComposesBoth() {
+        let details = ConnectionDetails(interface: .init(bsdName: "en0", displayName: "Wi-Fi"))
+        #expect(value("Name", in: details.interfaceRows) == "Wi-Fi (en0)")
+    }
+
+    @Test("Name row uses displayName alone when bsdName is nil")
+    func nameDisplayNameOnly() {
+        let details = ConnectionDetails(interface: .init(displayName: "Wi-Fi"))
+        #expect(value("Name", in: details.interfaceRows) == "Wi-Fi")
+    }
+
+    @Test("Name row uses bsdName alone when displayName is nil")
+    func nameBsdNameOnly() {
+        let details = ConnectionDetails(interface: .init(bsdName: "en0"))
+        #expect(value("Name", in: details.interfaceRows) == "en0")
+    }
+
+    @Test("Name row omitted when both names are nil")
+    func nameOmittedWhenBothNil() {
+        let details = ConnectionDetails(interface: .init(macAddress: "aa:bb:cc:dd:ee:ff"))
+        #expect(value("Name", in: details.interfaceRows) == nil)
+    }
+
+    @Test("MAC address and MTU rows reflect their fields")
+    func macAndMtuRows() {
+        let details = ConnectionDetails(
+            interface: .init(macAddress: "aa:bb:cc:dd:ee:ff", mtu: 1500)
+        )
+        #expect(value("MAC address", in: details.interfaceRows) == "aa:bb:cc:dd:ee:ff")
+        #expect(value("MTU", in: details.interfaceRows) == "1500")
+    }
+
+    @Test("Link speed under 1000 renders as whole Mbps")
+    func linkSpeedMbps() {
+        let details = ConnectionDetails(interface: .init(linkSpeedMbps: 866))
+        #expect(value("Link speed", in: details.interfaceRows) == "866 Mbps")
+    }
+
+    @Test("Link speed of 1000 renders as 1 Gbps with trailing zero stripped")
+    func linkSpeedOneGbps() {
+        let details = ConnectionDetails(interface: .init(linkSpeedMbps: 1000))
+        #expect(value("Link speed", in: details.interfaceRows) == "1 Gbps")
+    }
+
+    @Test("Link speed of 2500 renders as 2.5 Gbps")
+    func linkSpeedFractionalGbps() {
+        let details = ConnectionDetails(interface: .init(linkSpeedMbps: 2500))
+        #expect(value("Link speed", in: details.interfaceRows) == "2.5 Gbps")
+    }
+
+    // MARK: - Addressing group
+
+    @Test("An empty addressing block produces no rows")
+    func emptyAddressingHasNoRows() {
+        let details = ConnectionDetails(addressing: .init())
+        #expect(details.addressingRows.isEmpty)
+    }
+
+    @Test("Addressing rows appear in design order and omit nil fields")
+    func addressingRowsOrderAndOmission() {
+        let details = ConnectionDetails(
+            addressing: .init(
+                ipv6Address: "2a00::1",
+                subnetMask: "255.255.255.0",
+                routerAddress: "192.168.1.1",
+                hostname: "mac"
+            )
+        )
+        #expect(details.addressingRows.map(\.label) == [
+            "Router", "Subnet mask", "IPv6 (local)", "Hostname"
+        ])
+        #expect(value("Public IPv6", in: details.addressingRows) == nil)
+    }
+
+    // MARK: - DNS & DHCP group
+
+    @Test("DNS servers are comma-joined")
+    func dnsJoined() {
+        let details = ConnectionDetails(dnsDhcp: .init(dnsServers: ["1.1.1.1", "8.8.8.8"]))
+        #expect(value("DNS servers", in: details.dnsDhcpRows) == "1.1.1.1, 8.8.8.8")
+    }
+
+    @Test("Empty DNS and search-domain arrays produce no rows")
+    func emptyDnsArraysOmitted() {
+        let details = ConnectionDetails(dnsDhcp: .init())
+        #expect(value("DNS servers", in: details.dnsDhcpRows) == nil)
+        #expect(value("Search domains", in: details.dnsDhcpRows) == nil)
+    }
+
+    @Test("Search domains are comma-joined")
+    func searchDomainsJoined() {
+        let details = ConnectionDetails(dnsDhcp: .init(searchDomains: ["home", "lan"]))
+        #expect(value("Search domains", in: details.dnsDhcpRows) == "home, lan")
+    }
+
+    @Test("DHCP lease row present for a date, absent for nil")
+    func dhcpLeaseRowPresence() {
+        let withLease = ConnectionDetails(dnsDhcp: .init(dhcpLeaseExpiry: Date()))
+        #expect(value("DHCP lease expires", in: withLease.dnsDhcpRows) != nil)
+
+        let withoutLease = ConnectionDetails(dnsDhcp: .init())
+        #expect(value("DHCP lease expires", in: withoutLease.dnsDhcpRows) == nil)
+    }
+
+    // MARK: - Wi-Fi group
+
+    @Test("wifiRows is empty when wifi is nil")
+    func wifiRowsEmptyWhenNil() {
+        let details = ConnectionDetails()
+        #expect(details.wifi == nil)
+        #expect(details.wifiRows.isEmpty)
+    }
+
+    @Test("Channel row composes number, band, and width")
+    func channelFullComposition() {
+        let details = ConnectionDetails(
+            wifi: .init(channelNumber: 44, band: "5 GHz", channelWidthMHz: 80)
+        )
+        #expect(value("Channel", in: details.wifiRows) == "44 · 5 GHz · 80 MHz")
+    }
+
+    @Test("Channel row drops nil pieces")
+    func channelPartialComposition() {
+        let details = ConnectionDetails(
+            wifi: .init(channelNumber: 44, band: "5 GHz")
+        )
+        #expect(value("Channel", in: details.wifiRows) == "44 · 5 GHz")
+    }
+
+    @Test("Channel row omitted when all pieces are nil")
+    func channelOmittedWhenEmpty() {
+        let details = ConnectionDetails(wifi: .init(phyMode: "802.11ax"))
+        #expect(value("Channel", in: details.wifiRows) == nil)
+        #expect(value("PHY mode", in: details.wifiRows) == "802.11ax")
+    }
+
+    // MARK: - Mocks
+
+    @Test("mockWifi is fully populated with a Wi-Fi group")
+    func mockWifiPopulated() {
+        let mock = ConnectionDetails.mockWifi
+        #expect(mock.wifi != nil)
+        #expect(!mock.interfaceRows.isEmpty)
+        #expect(!mock.addressingRows.isEmpty)
+        #expect(!mock.dnsDhcpRows.isEmpty)
+        #expect(!mock.wifiRows.isEmpty)
+    }
+
+    @Test("mockEthernet has no Wi-Fi group and a 1000 Mbps link")
+    func mockEthernetPopulated() {
+        let mock = ConnectionDetails.mockEthernet
+        #expect(mock.wifi == nil)
+        #expect(mock.wifiRows.isEmpty)
+        #expect(value("Link speed", in: mock.interfaceRows) == "1 Gbps")
+    }
+
+    @Test("mockVPN exposes only router, DNS, and hostname")
+    func mockVPNPopulated() {
+        let mock = ConnectionDetails.mockVPN
+        #expect(mock.wifi == nil)
+        #expect(value("Router", in: mock.addressingRows) != nil)
+        #expect(value("Hostname", in: mock.addressingRows) != nil)
+        #expect(!mock.dnsDhcpRows.isEmpty)
+    }
+}

--- a/QuickNetStatsTests/ConnectionDetailsTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsTests.swift
@@ -74,6 +74,36 @@ struct ConnectionDetailsTests {
         #expect(value("Link speed", in: details.interfaceRows) == "2.5 Gbps")
     }
 
+    @Test("Media, Supports, and Also available rows follow Link speed in order")
+    func interfaceExtraRowsOrder() {
+        let details = ConnectionDetails(
+            interface: .init(
+                bsdName: "en5",
+                displayName: "Ethernet",
+                macAddress: "aa:bb:cc:dd:ee:ff",
+                mtu: 1500,
+                linkSpeedMbps: 1000,
+                mediaDescription: "1000baseT full-duplex",
+                supports: "IPv4 · IPv6 · DNS",
+                otherInterfaces: ["Wi-Fi (en0)", "Cellular (pdp_ip0)"]
+            )
+        )
+        #expect(details.interfaceRows.map(\.label) == [
+            "Name", "MAC address", "MTU", "Link speed", "Media", "Supports", "Also available"
+        ])
+        #expect(value("Media", in: details.interfaceRows) == "1000baseT full-duplex")
+        #expect(value("Supports", in: details.interfaceRows) == "IPv4 · IPv6 · DNS")
+        #expect(value("Also available", in: details.interfaceRows) == "Wi-Fi (en0), Cellular (pdp_ip0)")
+    }
+
+    @Test("Media, Supports, and Also available rows are omitted when unset")
+    func interfaceExtraRowsOmitted() {
+        let details = ConnectionDetails(interface: .init(bsdName: "en0"))
+        #expect(value("Media", in: details.interfaceRows) == nil)
+        #expect(value("Supports", in: details.interfaceRows) == nil)
+        #expect(value("Also available", in: details.interfaceRows) == nil)
+    }
+
     // MARK: - Addressing group
 
     @Test("An empty addressing block produces no rows")
@@ -96,6 +126,31 @@ struct ConnectionDetailsTests {
             "Router", "Subnet mask", "IPv6 (local)", "Hostname"
         ])
         #expect(value("Public IPv6", in: details.addressingRows) == nil)
+    }
+
+    @Test("All addressing rows appear in design order when populated")
+    func addressingFullOrder() {
+        let details = ConnectionDetails(
+            addressing: .init(
+                ipv6Address: "2a00::1",
+                publicIPv6: "2a01::2",
+                subnetMask: "255.255.255.0",
+                routerAddress: "192.168.1.1",
+                hostname: "mac",
+                ipv6Router: "fe80::1",
+                broadcastAddress: "192.168.1.255",
+                ipv4ConfigMethod: "DHCP",
+                computerName: "Federico's Mac"
+            )
+        )
+        #expect(details.addressingRows.map(\.label) == [
+            "Router", "Router (IPv6)", "Subnet mask", "Broadcast",
+            "IPv6 (local)", "Public IPv6", "IPv4 config", "Hostname", "Computer name"
+        ])
+        #expect(value("Router (IPv6)", in: details.addressingRows) == "fe80::1")
+        #expect(value("Broadcast", in: details.addressingRows) == "192.168.1.255")
+        #expect(value("IPv4 config", in: details.addressingRows) == "DHCP")
+        #expect(value("Computer name", in: details.addressingRows) == "Federico's Mac")
     }
 
     // MARK: - DNS & DHCP group
@@ -126,6 +181,56 @@ struct ConnectionDetailsTests {
 
         let withoutLease = ConnectionDetails(dnsDhcp: .init())
         #expect(value("DHCP lease expires", in: withoutLease.dnsDhcpRows) == nil)
+    }
+
+    @Test("DHCP server and Lease started rows precede Lease expires in order")
+    func dnsDhcpFullOrder() {
+        let details = ConnectionDetails(
+            dnsDhcp: .init(
+                dnsServers: ["1.1.1.1"],
+                searchDomains: ["home"],
+                dhcpServer: "192.168.1.1",
+                dhcpLeaseStart: Date(),
+                dhcpLeaseExpiry: Date().addingTimeInterval(86_400)
+            )
+        )
+        #expect(details.dnsDhcpRows.map(\.label) == [
+            "DNS servers", "Search domains", "DHCP server", "Lease started", "DHCP lease expires"
+        ])
+        #expect(value("DHCP server", in: details.dnsDhcpRows) == "192.168.1.1")
+        #expect(value("Lease started", in: details.dnsDhcpRows) != nil)
+    }
+
+    @Test("DHCP server and Lease started rows are omitted when unset")
+    func dnsDhcpExtraRowsOmitted() {
+        let details = ConnectionDetails(dnsDhcp: .init(dnsServers: ["1.1.1.1"]))
+        #expect(value("DHCP server", in: details.dnsDhcpRows) == nil)
+        #expect(value("Lease started", in: details.dnsDhcpRows) == nil)
+    }
+
+    // MARK: - Proxy group
+
+    @Test("A fully populated proxy yields three rows in HTTP/HTTPS/SOCKS order")
+    func proxyFullRows() {
+        let details = ConnectionDetails(
+            proxy: .init(httpProxy: "p.local:80", httpsProxy: "p.local:443", socksProxy: "s.local:1080")
+        )
+        #expect(details.proxyRows.map(\.label) == ["HTTP", "HTTPS", "SOCKS"])
+        #expect(value("HTTP", in: details.proxyRows) == "p.local:80")
+        #expect(value("HTTPS", in: details.proxyRows) == "p.local:443")
+        #expect(value("SOCKS", in: details.proxyRows) == "s.local:1080")
+    }
+
+    @Test("A partially populated proxy omits the nil entries")
+    func proxyPartialRows() {
+        let details = ConnectionDetails(proxy: .init(httpsProxy: "p.local:443"))
+        #expect(details.proxyRows.map(\.label) == ["HTTPS"])
+    }
+
+    @Test("An all-nil proxy produces no rows so the group never renders")
+    func proxyEmptyRows() {
+        let details = ConnectionDetails()
+        #expect(details.proxyRows.isEmpty)
     }
 
     // MARK: - Wi-Fi group
@@ -160,6 +265,60 @@ struct ConnectionDetailsTests {
         #expect(value("PHY mode", in: details.wifiRows) == "802.11ax")
     }
 
+    // MARK: - Wi-Fi generation
+
+    @Test("PHY mode maps to its Wi-Fi generation", arguments: [
+        ("802.11b", "Wi-Fi 1"),
+        ("802.11a", "Wi-Fi 2"),
+        ("802.11g", "Wi-Fi 3"),
+        ("802.11n", "Wi-Fi 4"),
+        ("802.11ac", "Wi-Fi 5"),
+        ("802.11be", "Wi-Fi 7")
+    ])
+    func phyModeMapsToGeneration(phy: String, expected: String) {
+        #expect(ConnectionDetails.Wifi(phyMode: phy).generation == expected)
+    }
+
+    @Test("802.11ax on 6 GHz is Wi-Fi 6E")
+    func axSixGigIsSixE() {
+        let wifi = ConnectionDetails.Wifi(band: "6 GHz", phyMode: "802.11ax")
+        #expect(wifi.generation == "Wi-Fi 6E")
+    }
+
+    @Test("802.11ax below 6 GHz is Wi-Fi 6", arguments: [Optional("5 GHz"), nil])
+    func axBelowSixGigIsSix(band: String?) {
+        let wifi = ConnectionDetails.Wifi(band: band, phyMode: "802.11ax")
+        #expect(wifi.generation == "Wi-Fi 6")
+    }
+
+    @Test("nil PHY mode yields no generation and omits the row")
+    func nilPhyModeNoGeneration() {
+        let details = ConnectionDetails(wifi: .init(channelNumber: 44, band: "5 GHz"))
+        #expect(details.wifi?.generation == nil)
+        #expect(value("Generation", in: details.wifiRows) == nil)
+    }
+
+    @Test("Generation row follows PHY mode in a fully populated Wi-Fi group")
+    func generationRowPosition() {
+        let mock = ConnectionDetails.mockWifi
+        #expect(mock.wifiRows.map(\.label) == [
+            "Channel", "PHY mode", "Generation", "Mode", "Tx power", "Security", "Country code"
+        ])
+        #expect(value("Generation", in: mock.wifiRows) == "Wi-Fi 6")
+    }
+
+    @Test("Mode and Tx power rows follow Generation and omit when unset")
+    func wifiModeAndTxPowerRows() {
+        let populated = ConnectionDetails(wifi: .init(phyMode: "802.11ax", mode: "Station", txPowerMw: 100))
+        #expect(value("Mode", in: populated.wifiRows) == "Station")
+        #expect(value("Tx power", in: populated.wifiRows) == "100 mW")
+        #expect(populated.wifiRows.map(\.label) == ["PHY mode", "Generation", "Mode", "Tx power"])
+
+        let bare = ConnectionDetails(wifi: .init(phyMode: "802.11ax"))
+        #expect(value("Mode", in: bare.wifiRows) == nil)
+        #expect(value("Tx power", in: bare.wifiRows) == nil)
+    }
+
     // MARK: - Mocks
 
     @Test("mockWifi is fully populated with a Wi-Fi group")
@@ -170,6 +329,27 @@ struct ConnectionDetailsTests {
         #expect(!mock.addressingRows.isEmpty)
         #expect(!mock.dnsDhcpRows.isEmpty)
         #expect(!mock.wifiRows.isEmpty)
+    }
+
+    @Test("mockWifi exercises the new fields and proxy group")
+    func mockWifiHasNewFields() {
+        let mock = ConnectionDetails.mockWifi
+        #expect(mock.interface.supports != nil)
+        #expect(!mock.interface.otherInterfaces.isEmpty)
+        #expect(mock.addressing.ipv6Router != nil)
+        #expect(mock.addressing.computerName != nil)
+        #expect(mock.dnsDhcp.dhcpServer != nil)
+        #expect(mock.dnsDhcp.dhcpLeaseStart != nil)
+        #expect(!mock.proxyRows.isEmpty)
+        #expect(mock.wifi?.mode != nil)
+        #expect(mock.wifi?.txPowerMw != nil)
+    }
+
+    @Test("mockEthernet reports a media description and no proxy group")
+    func mockEthernetHasMedia() {
+        let mock = ConnectionDetails.mockEthernet
+        #expect(mock.interface.mediaDescription != nil)
+        #expect(mock.proxyRows.isEmpty)
     }
 
     @Test("mockEthernet has no Wi-Fi group and a 1000 Mbps link")
@@ -187,5 +367,18 @@ struct ConnectionDetailsTests {
         #expect(value("Router", in: mock.addressingRows) != nil)
         #expect(value("Hostname", in: mock.addressingRows) != nil)
         #expect(!mock.dnsDhcpRows.isEmpty)
+    }
+
+    @Test("mockVPN leaves the new fields nil to exercise omission")
+    func mockVPNOmitsNewFields() {
+        let mock = ConnectionDetails.mockVPN
+        #expect(mock.interface.mediaDescription == nil)
+        #expect(mock.interface.supports == nil)
+        #expect(mock.interface.otherInterfaces.isEmpty)
+        #expect(mock.addressing.ipv6Router == nil)
+        #expect(mock.addressing.broadcastAddress == nil)
+        #expect(mock.addressing.ipv4ConfigMethod == nil)
+        #expect(mock.addressing.computerName == nil)
+        #expect(mock.proxyRows.isEmpty)
     }
 }

--- a/QuickNetStatsTests/ConnectionDetailsTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsTests.swift
@@ -118,6 +118,30 @@ struct ConnectionDetailsTests {
         #expect(value("Also available", in: details.interfaceRows) == nil)
     }
 
+    // MARK: - Interface BSSID
+
+    @Test("interfaceRows includes BSSID after MAC address when opted in")
+    func interfaceRowsIncludeBSSIDWhenOptedIn() {
+        let rows = ConnectionDetails.mockWifi.interfaceRows(includeBSSID: true)
+        let labels = rows.map(\.label)
+        #expect(rows.contains(DetailRow(label: "BSSID", value: "aa:bb:cc:11:22:33")))
+        #expect(labels.firstIndex(of: "BSSID") == labels.firstIndex(of: "MAC address").map { $0 + 1 })
+    }
+
+    @Test("interfaceRows omits BSSID by default")
+    func interfaceRowsOmitBSSIDByDefault() {
+        let labels = ConnectionDetails.mockWifi.interfaceRows().map(\.label)
+        #expect(!labels.contains("BSSID"))
+    }
+
+    @Test("interfaceRows omits BSSID when the value is missing")
+    func interfaceRowsOmitNilBSSID() {
+        var details = ConnectionDetails.mockWifi
+        details.interface.bssid = nil
+        let labels = details.interfaceRows(includeBSSID: true).map(\.label)
+        #expect(!labels.contains("BSSID"))
+    }
+
     // MARK: - Addressing group
 
     @Test("An empty addressing block produces no rows")

--- a/QuickNetStatsTests/ConnectionDetailsViewTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsViewTests.swift
@@ -3,7 +3,7 @@
 //  QuickNetStatsTests
 //
 //  Tests for ConnectionDetailsView: dynamic scroll-height cap derived from the
-//  current screen height.
+//  current screen height, visible area, and measured popover chrome.
 //
 
 import Testing
@@ -17,14 +17,32 @@ struct ConnectionDetailsViewTests {
     // MARK: - Max details height
 
     @Test(
-        "maxDetailsHeight is 3/4 of the screen height, or the 600 fallback when unknown",
+        "maxDetailsHeight bounds the details cap by screen, visible area, and chrome",
         arguments: [
-            (CGFloat(1080), CGFloat(810)),
-            (CGFloat(2000), CGFloat(1500)),
-            (nil, CGFloat(600)),
-        ] as [(CGFloat?, CGFloat)]
+            // Unknown screen falls back to the fixed 600 cap.
+            (nil, nil, nil, CGFloat(600)),
+            // Plain 3/4 bound when the visible/chrome measurements are unavailable.
+            (CGFloat(956), nil, nil, CGFloat(717)),
+            // Large display: the 3/4 bound stays the binding one.
+            (CGFloat(1440), CGFloat(1400), CGFloat(300), CGFloat(1080)),
+            // 13" MacBook Air: the visible-minus-chrome bound wins so nothing overflows.
+            (CGFloat(956), CGFloat(860), CGFloat(300), CGFloat(544)),
+            // Absurd chrome can never collapse the details below the floor.
+            (CGFloat(956), CGFloat(860), CGFloat(900), CGFloat(100)),
+        ] as [(CGFloat?, CGFloat?, CGFloat?, CGFloat)]
     )
-    func maxDetailsHeightForScreenHeight(screenHeight: CGFloat?, expected: CGFloat) {
-        #expect(ConnectionDetailsView.maxDetailsHeight(forScreenHeight: screenHeight) == expected)
+    func maxDetailsHeightBounds(
+        screenHeight: CGFloat?,
+        visibleHeight: CGFloat?,
+        chromeHeight: CGFloat?,
+        expected: CGFloat
+    ) {
+        #expect(
+            ConnectionDetailsView.maxDetailsHeight(
+                screenHeight: screenHeight,
+                visibleHeight: visibleHeight,
+                chromeHeight: chromeHeight
+            ) == expected
+        )
     }
 }

--- a/QuickNetStatsTests/ConnectionDetailsViewTests.swift
+++ b/QuickNetStatsTests/ConnectionDetailsViewTests.swift
@@ -1,0 +1,30 @@
+//
+//  ConnectionDetailsViewTests.swift
+//  QuickNetStatsTests
+//
+//  Tests for ConnectionDetailsView: dynamic scroll-height cap derived from the
+//  current screen height.
+//
+
+import Testing
+import SwiftUI
+@testable import QuickNetStats
+
+@Suite("ConnectionDetailsView")
+@MainActor
+struct ConnectionDetailsViewTests {
+
+    // MARK: - Max details height
+
+    @Test(
+        "maxDetailsHeight is 3/4 of the screen height, or the 600 fallback when unknown",
+        arguments: [
+            (CGFloat(1080), CGFloat(810)),
+            (CGFloat(2000), CGFloat(1500)),
+            (nil, CGFloat(600)),
+        ] as [(CGFloat?, CGFloat)]
+    )
+    func maxDetailsHeightForScreenHeight(screenHeight: CGFloat?, expected: CGFloat) {
+        #expect(ConnectionDetailsView.maxDetailsHeight(forScreenHeight: screenHeight) == expected)
+    }
+}

--- a/QuickNetStatsTests/ConnectionReadersTests.swift
+++ b/QuickNetStatsTests/ConnectionReadersTests.swift
@@ -30,6 +30,24 @@ struct SystemConfigReaderTests {
             #expect(primary.range(of: "^[a-z]+[0-9]+$", options: .regularExpression) != nil)
         }
     }
+
+    @Test("snapshot() fills the extended fields with sane types and no crash")
+    func extendedSnapshotDoesNotCrash() {
+        let snapshot = SystemConfigReader().snapshot()
+        // The proxies struct is always present; individual proxies may be nil.
+        let proxies = snapshot.proxies
+        _ = (proxies.http, proxies.https, proxies.socks)
+        // computerName, when present, is non-empty.
+        if let name = snapshot.computerName { #expect(!name.isEmpty) }
+        // ipv4ConfigMethod, when present, is a non-empty token (e.g. "DHCP").
+        if let method = snapshot.ipv4ConfigMethod { #expect(!method.isEmpty) }
+        // dhcpServer, when present, looks like a dotted-quad IPv4 address.
+        if let server = snapshot.dhcpServer {
+            #expect(server.range(of: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$", options: .regularExpression) != nil)
+        }
+        // ipv6Router, when present, is non-empty.
+        if let router = snapshot.ipv6Router { #expect(!router.isEmpty) }
+    }
 }
 
 @Suite("InterfaceReader")
@@ -43,18 +61,62 @@ struct InterfaceReaderTests {
         #expect(InterfaceReader.preferredIPv6(from: []) == nil)
     }
 
-    @Test("snapshot(for: lo0) returns an MTU and byte counters without crashing")
+    @Test("snapshot(for: lo0) returns MTU, byte and packet counters without crashing")
     func loopbackSnapshot() {
         let snapshot = InterfaceReader().snapshot(for: "lo0")
         #expect(snapshot.mtu != nil)
         #expect(snapshot.rxBytes != nil)
         #expect(snapshot.txBytes != nil)
+        #expect(snapshot.rxPackets != nil)
+        #expect(snapshot.txPackets != nil)
+        #expect(snapshot.inErrors != nil)
+        #expect(snapshot.outErrors != nil)
+        #expect(snapshot.drops != nil)
     }
 
     @Test("snapshot for a nonexistent interface is entirely nil")
     func bogusInterfaceSnapshot() {
         let snapshot = InterfaceReader().snapshot(for: "definitely-not-real99")
         #expect(snapshot == InterfaceSnapshot())
+    }
+
+    @Test("lo0 reports no Ethernet media description")
+    func loopbackHasNoMedia() {
+        #expect(InterfaceReader().snapshot(for: "lo0").mediaDescription == nil)
+    }
+
+    @Test("mediaDescription maps known Ethernet subtypes with duplex", arguments: [
+        (Int32(IFM_ETHER) | Int32(IFM_1000_T) | Int32(IFM_FDX), "1000baseT full-duplex"),
+        (Int32(IFM_ETHER) | Int32(IFM_100_TX) | Int32(IFM_HDX), "100baseTX half-duplex"),
+        (Int32(IFM_ETHER) | Int32(IFM_10_T) | Int32(IFM_FDX), "10baseT full-duplex"),
+        (Int32(IFM_ETHER) | Int32(IFM_2500_T), "2500baseT"),
+        (Int32(IFM_ETHER) | Int32(IFM_5000_T), "5000baseT"),
+        (Int32(IFM_ETHER) | Int32(IFM_10G_T), "10GbaseT")
+    ])
+    func mediaDescriptionMapping(active: Int32, expected: String) {
+        #expect(InterfaceReader.mediaDescription(active: active) == expected)
+    }
+
+    @Test("mediaDescription is nil for non-Ethernet and unmapped subtypes")
+    func mediaDescriptionNil() {
+        #expect(InterfaceReader.mediaDescription(active: 0) == nil)
+        #expect(InterfaceReader.mediaDescription(active: Int32(IFM_ETHER) | 0x1f) == nil)
+    }
+
+    @Test("Extended counters and broadcast, when present on a physical interface, are well-typed")
+    func physicalInterfaceExtras() {
+        for name in ["en0", "en1"] {
+            let snapshot = InterfaceReader().snapshot(for: name)
+            // A live interface reporting bytes must also report packet counters.
+            if snapshot.rxBytes != nil {
+                #expect(snapshot.rxPackets != nil)
+                #expect(snapshot.txPackets != nil)
+            }
+            // A broadcast address, when present, is a dotted-quad IPv4 literal.
+            if let broadcast = snapshot.broadcastAddress {
+                #expect(broadcast.range(of: "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$", options: .regularExpression) != nil)
+            }
+        }
     }
 }
 
@@ -75,5 +137,43 @@ struct WifiReaderTests {
                 #expect((-100...0).contains(rssi))
             }
         }
+    }
+
+    @Test("interface mode maps station/IBSS/hostAP by rawValue", arguments: [
+        (1, "Station"), (2, "IBSS"), (3, "Host AP")
+    ])
+    func modeMapping(raw: Int, expected: String) {
+        #expect(WifiReader.modeText(raw) == expected)
+    }
+
+    @Test("unknown or none interface-mode raw values map to nil")
+    func modeMappingNil() {
+        #expect(WifiReader.modeText(0) == nil)
+        #expect(WifiReader.modeText(99) == nil)
+    }
+
+    @Test("A real Wi-Fi snapshot, when present, reports a positive or nil tx power")
+    func txPowerPlausible() {
+        for name in ["en0", "en1"] {
+            if let snapshot = WifiReader().snapshot(for: name), let power = snapshot.txPowerMw {
+                #expect(power > 0)
+            }
+        }
+    }
+}
+
+@Suite("PathReader")
+struct PathReaderTests {
+
+    @Test("snapshot returns within the timeout and yields a usable PathSnapshot")
+    func snapshotReturnsPromptly() async {
+        let start = ContinuousClock.now
+        let snapshot = await PathReader(timeout: 2.0).snapshot(excluding: "en0")
+        let elapsed = ContinuousClock.now - start
+        // Must return well before the timeout ceiling (the first callback is prompt).
+        #expect(elapsed < .seconds(3))
+        // otherInterfaces never lists the excluded primary or a loopback.
+        #expect(!snapshot.otherInterfaces.contains { $0.contains("(en0)") })
+        #expect(!snapshot.otherInterfaces.contains { $0.lowercased().contains("loopback") })
     }
 }

--- a/QuickNetStatsTests/ConnectionReadersTests.swift
+++ b/QuickNetStatsTests/ConnectionReadersTests.swift
@@ -1,0 +1,79 @@
+//
+//  ConnectionReadersTests.swift
+//  QuickNetStatsTests
+//
+//  Smoke + pure-logic tests for the three connection-detail readers.
+//  Assertions are deliberately lenient: CI machines may have no active Wi-Fi,
+//  no IPv6, or a headless network, so these confirm the readers run without
+//  crashing and return well-typed values rather than asserting specific data.
+//
+
+import Testing
+import Foundation
+@testable import QuickNetStats
+
+@Suite("SystemConfigReader")
+struct SystemConfigReaderTests {
+
+    @Test("snapshot() returns without crashing and yields typed arrays")
+    func snapshotDoesNotCrash() {
+        let snapshot = SystemConfigReader().snapshot()
+        // Arrays are always present (possibly empty on CI).
+        #expect(snapshot.dnsServers.count >= 0)
+        #expect(snapshot.searchDomains.count >= 0)
+    }
+
+    @Test("primaryInterface, when present, looks like a BSD interface name")
+    func primaryInterfaceShape() {
+        let snapshot = SystemConfigReader().snapshot()
+        if let primary = snapshot.primaryInterface {
+            #expect(primary.range(of: "^[a-z]+[0-9]+$", options: .regularExpression) != nil)
+        }
+    }
+}
+
+@Suite("InterfaceReader")
+struct InterfaceReaderTests {
+
+    @Test("preferredIPv6 prefers global unicast, then ULA, and never link-local")
+    func preferredIPv6Order() {
+        #expect(InterfaceReader.preferredIPv6(from: ["fe80::1", "2a00:1::2", "fd12::1"]) == "2a00:1::2")
+        #expect(InterfaceReader.preferredIPv6(from: ["fe80::1", "fd12::1"]) == "fd12::1")
+        #expect(InterfaceReader.preferredIPv6(from: ["FE80::1"]) == nil)
+        #expect(InterfaceReader.preferredIPv6(from: []) == nil)
+    }
+
+    @Test("snapshot(for: lo0) returns an MTU and byte counters without crashing")
+    func loopbackSnapshot() {
+        let snapshot = InterfaceReader().snapshot(for: "lo0")
+        #expect(snapshot.mtu != nil)
+        #expect(snapshot.rxBytes != nil)
+        #expect(snapshot.txBytes != nil)
+    }
+
+    @Test("snapshot for a nonexistent interface is entirely nil")
+    func bogusInterfaceSnapshot() {
+        let snapshot = InterfaceReader().snapshot(for: "definitely-not-real99")
+        #expect(snapshot == InterfaceSnapshot())
+    }
+}
+
+@Suite("WifiReader")
+struct WifiReaderTests {
+
+    @Test("A non-Wi-Fi interface (lo0) yields a nil snapshot")
+    func loopbackHasNoWifi() {
+        #expect(WifiReader().snapshot(for: "lo0") == nil)
+    }
+
+    @Test("A real Wi-Fi snapshot, when present, reports a plausible RSSI")
+    func wifiRssiPlausible() {
+        // Lenient: on CI there may be no Wi-Fi; only assert when a snapshot with
+        // RSSI is actually produced. Tries the usual physical-interface names.
+        for name in ["en0", "en1"] {
+            if let snapshot = WifiReader().snapshot(for: name), let rssi = snapshot.rssiDBm {
+                #expect((-100...0).contains(rssi))
+            }
+        }
+    }
+}

--- a/QuickNetStatsTests/DataRateTests.swift
+++ b/QuickNetStatsTests/DataRateTests.swift
@@ -1,0 +1,116 @@
+//
+//  DataRateTests.swift
+//  QuickNetStatsTests
+//
+
+import Testing
+import Foundation
+@testable import QuickNetStats
+
+@Suite("RateUnit")
+struct RateUnitTests {
+
+    @Test(
+        "Raw values match their unit abbreviation",
+        arguments: [
+            (RateUnit.bitsPerSecond, "bps"),
+            (RateUnit.bytesPerSecond, "B/s"),
+        ]
+    )
+    func rawValues(unit: RateUnit, expected: String) {
+        #expect(unit.rawValue == expected)
+    }
+
+    @Test("id matches rawValue for each unit")
+    func idMatchesRawValue() {
+        for unit in RateUnit.allCases {
+            #expect(unit.id == unit.rawValue)
+        }
+    }
+
+    @Test("allCases contains exactly the two families in order")
+    func allCasesOrder() {
+        #expect(RateUnit.allCases == [.bitsPerSecond, .bytesPerSecond])
+    }
+
+    @Test("displayName describes the family with a sample multiple")
+    func displayNames() {
+        #expect(RateUnit.bitsPerSecond.displayName == "Bits per second (Mbps)")
+        #expect(RateUnit.bytesPerSecond.displayName == "Bytes per second (MB/s)")
+    }
+}
+
+@Suite("DataRate")
+struct DataRateTests {
+
+    // MARK: - Conversions
+
+    @Test("bitsToBytes divides by 8")
+    func bitsToBytes() {
+        #expect(DataRate.bitsToBytes(8) == 1)
+        #expect(DataRate.bitsToBytes(210_000_000) == 26_250_000)
+    }
+
+    @Test("bytesToBits multiplies by 8")
+    func bytesToBits() {
+        #expect(DataRate.bytesToBits(1) == 8)
+        #expect(DataRate.bytesToBits(26_250_000) == 210_000_000)
+    }
+
+    @Test("conversions round-trip losslessly")
+    func conversionRoundTrip() {
+        #expect(DataRate.bytesToBits(DataRate.bitsToBytes(1_000_000)) == 1_000_000)
+        #expect(DataRate.bitsToBytes(DataRate.bytesToBits(500_000)) == 500_000)
+    }
+
+    // MARK: - Bits family formatting
+
+    @Test(
+        "Bits values scale to the largest multiple with stripped decimals",
+        arguments: [
+            (0.0, "0 bps"),
+            (999.0, "999 bps"),
+            (1_000.0, "1 Kbps"),
+            (1_500.0, "1.5 Kbps"),
+            (866_000_000.0, "866 Mbps"),
+            (1_000_000_000.0, "1 Gbps"),
+            (2_500_000_000.0, "2.5 Gbps"),
+        ]
+    )
+    func bitsFormatting(input: Double, expected: String) {
+        #expect(DataRate.text(bitsPerSecond: input, in: .bitsPerSecond) == expected)
+    }
+
+    // MARK: - Bytes family formatting
+
+    @Test(
+        "Bytes values scale to the largest multiple with stripped decimals",
+        arguments: [
+            (0.0, "0 B/s"),
+            (0.13, "0.13 B/s"),
+            (999.0, "999 B/s"),
+            (1_000.0, "1 KB/s"),
+            (1_000_000.0, "1 MB/s"),
+            (1_000_000_000.0, "1 GB/s"),
+            (26_250_000.0, "26.25 MB/s"),
+        ]
+    )
+    func bytesFormatting(input: Double, expected: String) {
+        #expect(DataRate.text(bytesPerSecond: input, in: .bytesPerSecond) == expected)
+    }
+
+    // MARK: - Cross-family display (convert then format)
+
+    @Test("A bits rate displayed in bytes converts before scaling")
+    func bitsShownInBytes() {
+        // Canonical example: 210 Mbps link speed shown in bytes.
+        #expect(DataRate.text(bitsPerSecond: 210_000_000, in: .bytesPerSecond) == "26.25 MB/s")
+        #expect(DataRate.text(bitsPerSecond: 866_000_000, in: .bytesPerSecond) == "108.25 MB/s")
+    }
+
+    @Test("A bytes rate displayed in bits converts before scaling")
+    func bytesShownInBits() {
+        // 1 GB/s == 8 Gbps.
+        #expect(DataRate.text(bytesPerSecond: 1_000_000_000, in: .bitsPerSecond) == "8 Gbps")
+    }
+}

--- a/QuickNetStatsTests/LiveConnectionStatsTests.swift
+++ b/QuickNetStatsTests/LiveConnectionStatsTests.swift
@@ -59,6 +59,42 @@ struct LiveConnectionStatsTests {
         #expect(stats.uploadText == "340.0 KB/s")
     }
 
+    // MARK: - Packet / error / drop rates
+
+    @Test("countRateText rounds to a whole integer and appends /s", arguments: [
+        (0.0, "0/s"),
+        (0.4, "0/s"),
+        (0.6, "1/s"),
+        (1_234.0, "1234/s"),
+        (1_234.7, "1235/s")
+    ])
+    func countRateTextRounds(input: Double, expected: String) {
+        #expect(LiveConnectionStats.countRateText(input) == expected)
+    }
+
+    @Test("packet/error/drop text fields use the integer-rate formatter")
+    func counterText() {
+        let stats = LiveConnectionStats(
+            downloadPacketsPerSec: 1_234,
+            uploadPacketsPerSec: 56,
+            errorsPerSec: 0,
+            dropsPerSec: 2
+        )
+        #expect(stats.downloadPacketsText == "1234/s")
+        #expect(stats.uploadPacketsText == "56/s")
+        #expect(stats.errorsText == "0/s")
+        #expect(stats.dropsText == "2/s")
+    }
+
+    @Test("packet/error/drop text fields are nil when values are missing")
+    func counterTextNil() {
+        let stats = LiveConnectionStats()
+        #expect(stats.downloadPacketsText == nil)
+        #expect(stats.uploadPacketsText == nil)
+        #expect(stats.errorsText == nil)
+        #expect(stats.dropsText == nil)
+    }
+
     // MARK: - rateText boundaries
 
     @Test("rateText formats bytes per second across magnitude boundaries", arguments: [
@@ -79,17 +115,23 @@ struct LiveConnectionStatsTests {
         let mock = LiveConnectionStats.mockLiveWifi
         #expect(mock.downloadBytesPerSec != nil)
         #expect(mock.uploadBytesPerSec != nil)
+        #expect(mock.downloadPacketsPerSec != nil)
+        #expect(mock.uploadPacketsPerSec != nil)
+        #expect(mock.errorsPerSec != nil)
+        #expect(mock.dropsPerSec != nil)
         #expect(mock.rssiDBm != nil)
         #expect(mock.noiseDBm != nil)
         #expect(mock.txRateMbps != nil)
         #expect(mock.snrDB != nil)
     }
 
-    @Test("mockLiveWired has throughput only")
+    @Test("mockLiveWired has throughput and counters but no RF")
     func mockWiredPopulated() {
         let mock = LiveConnectionStats.mockLiveWired
         #expect(mock.downloadBytesPerSec != nil)
         #expect(mock.uploadBytesPerSec != nil)
+        #expect(mock.downloadPacketsPerSec != nil)
+        #expect(mock.uploadPacketsPerSec != nil)
         #expect(mock.rssiDBm == nil)
         #expect(mock.noiseDBm == nil)
         #expect(mock.txRateMbps == nil)

--- a/QuickNetStatsTests/LiveConnectionStatsTests.swift
+++ b/QuickNetStatsTests/LiveConnectionStatsTests.swift
@@ -1,0 +1,97 @@
+//
+//  LiveConnectionStatsTests.swift
+//  QuickNetStatsTests
+//
+
+import Testing
+import Foundation
+@testable import QuickNetStats
+
+@Suite("LiveConnectionStats")
+struct LiveConnectionStatsTests {
+
+    // MARK: - SNR
+
+    @Test("snrDB is rssi minus noise when both are present")
+    func snrComputed() {
+        let stats = LiveConnectionStats(rssiDBm: -52, noiseDBm: -95)
+        #expect(stats.snrDB == 43)
+    }
+
+    @Test("snrDB is nil when rssi is missing")
+    func snrNilWithoutRssi() {
+        let stats = LiveConnectionStats(noiseDBm: -95)
+        #expect(stats.snrDB == nil)
+    }
+
+    @Test("snrDB is nil when noise is missing")
+    func snrNilWithoutNoise() {
+        let stats = LiveConnectionStats(rssiDBm: -52)
+        #expect(stats.snrDB == nil)
+    }
+
+    // MARK: - Text formatting
+
+    @Test("RF text fields format with units")
+    func rfText() {
+        let stats = LiveConnectionStats(rssiDBm: -52, noiseDBm: -95, txRateMbps: 866)
+        #expect(stats.rssiText == "-52 dBm")
+        #expect(stats.noiseText == "-95 dBm")
+        #expect(stats.snrText == "43 dB")
+        #expect(stats.txRateText == "866 Mbps")
+    }
+
+    @Test("RF text fields are nil when values are missing")
+    func rfTextNil() {
+        let stats = LiveConnectionStats()
+        #expect(stats.rssiText == nil)
+        #expect(stats.noiseText == nil)
+        #expect(stats.snrText == nil)
+        #expect(stats.txRateText == nil)
+        #expect(stats.downloadText == nil)
+        #expect(stats.uploadText == nil)
+    }
+
+    @Test("download/upload text use the byte-rate formatter")
+    func throughputText() {
+        let stats = LiveConnectionStats(downloadBytesPerSec: 1_200_000, uploadBytesPerSec: 340_000)
+        #expect(stats.downloadText == "1.2 MB/s")
+        #expect(stats.uploadText == "340.0 KB/s")
+    }
+
+    // MARK: - rateText boundaries
+
+    @Test("rateText formats bytes per second across magnitude boundaries", arguments: [
+        (999.0, "999 B/s"),
+        (1_000.0, "1.0 KB/s"),
+        (999_999.0, "1000.0 KB/s"),
+        (1_000_000.0, "1.0 MB/s"),
+        (1_500_000_000.0, "1.5 GB/s")
+    ])
+    func rateTextBoundaries(input: Double, expected: String) {
+        #expect(LiveConnectionStats.rateText(input) == expected)
+    }
+
+    // MARK: - Mocks
+
+    @Test("mockLiveWifi has all fields populated")
+    func mockWifiPopulated() {
+        let mock = LiveConnectionStats.mockLiveWifi
+        #expect(mock.downloadBytesPerSec != nil)
+        #expect(mock.uploadBytesPerSec != nil)
+        #expect(mock.rssiDBm != nil)
+        #expect(mock.noiseDBm != nil)
+        #expect(mock.txRateMbps != nil)
+        #expect(mock.snrDB != nil)
+    }
+
+    @Test("mockLiveWired has throughput only")
+    func mockWiredPopulated() {
+        let mock = LiveConnectionStats.mockLiveWired
+        #expect(mock.downloadBytesPerSec != nil)
+        #expect(mock.uploadBytesPerSec != nil)
+        #expect(mock.rssiDBm == nil)
+        #expect(mock.noiseDBm == nil)
+        #expect(mock.txRateMbps == nil)
+    }
+}

--- a/QuickNetStatsTests/LiveConnectionStatsTests.swift
+++ b/QuickNetStatsTests/LiveConnectionStatsTests.swift
@@ -59,6 +59,49 @@ struct LiveConnectionStatsTests {
         #expect(stats.uploadText == "340.0 KB/s")
     }
 
+    // MARK: - Parameterized rate text (units)
+
+    @Test("downloadText(in:) keeps the native byte format and converts to bits")
+    func downloadTextUnits() {
+        let stats = LiveConnectionStats(downloadBytesPerSec: 1_200_000)
+        #expect(stats.downloadText(in: .bytesPerSecond) == "1.2 MB/s")
+        #expect(stats.downloadText(in: .bitsPerSecond) == "9.6 Mbps")
+    }
+
+    @Test("uploadText(in:) keeps the native byte format and converts to bits")
+    func uploadTextUnits() {
+        let stats = LiveConnectionStats(uploadBytesPerSec: 340_000)
+        #expect(stats.uploadText(in: .bytesPerSecond) == "340.0 KB/s")
+        #expect(stats.uploadText(in: .bitsPerSecond) == "2.72 Mbps")
+    }
+
+    @Test("txRateText(in:) keeps the native bit format and converts to bytes")
+    func txRateTextUnits() {
+        let stats = LiveConnectionStats(txRateMbps: 210)
+        #expect(stats.txRateText(in: .bitsPerSecond) == "210 Mbps")
+        #expect(stats.txRateText(in: .bytesPerSecond) == "26.25 MB/s")
+    }
+
+    @Test("parameterized text funcs stay nil when their value is missing")
+    func parameterizedTextNil() {
+        let stats = LiveConnectionStats()
+        #expect(stats.downloadText(in: .bitsPerSecond) == nil)
+        #expect(stats.uploadText(in: .bytesPerSecond) == nil)
+        #expect(stats.txRateText(in: .bitsPerSecond) == nil)
+    }
+
+    @Test("existing computed text properties stay in their native unit")
+    func nativeComputedPropertiesUnchanged() {
+        let stats = LiveConnectionStats(
+            downloadBytesPerSec: 340_000,
+            uploadBytesPerSec: 340_000,
+            txRateMbps: 210
+        )
+        #expect(stats.downloadText == "340.0 KB/s")
+        #expect(stats.uploadText == "340.0 KB/s")
+        #expect(stats.txRateText == "210 Mbps")
+    }
+
     // MARK: - Packet / error / drop rates
 
     @Test("countRateText rounds to a whole integer and appends /s", arguments: [

--- a/QuickNetStatsTests/LocationPermissionManagerTests.swift
+++ b/QuickNetStatsTests/LocationPermissionManagerTests.swift
@@ -1,0 +1,25 @@
+//
+//  LocationPermissionManagerTests.swift
+//  QuickNetStatsTests
+//
+
+import Testing
+import CoreLocation
+@testable import QuickNetStats
+
+@Suite("LocationPermissionManager")
+struct LocationPermissionManagerTests {
+
+    @Test(
+        "CLAuthorizationStatus maps to the app's three states",
+        arguments: [
+            (CLAuthorizationStatus.notDetermined, LocationAuthorizationState.notDetermined),
+            (CLAuthorizationStatus.authorizedAlways, LocationAuthorizationState.authorized),
+            (CLAuthorizationStatus.denied, LocationAuthorizationState.denied),
+            (CLAuthorizationStatus.restricted, LocationAuthorizationState.denied),
+        ]
+    )
+    func statusMapping(status: CLAuthorizationStatus, expected: LocationAuthorizationState) {
+        #expect(LocationPermissionManager.state(from: status) == expected)
+    }
+}

--- a/QuickNetStatsTests/NetStatsViewModelTests.swift
+++ b/QuickNetStatsTests/NetStatsViewModelTests.swift
@@ -28,6 +28,23 @@ struct NetStatsViewModelTests {
         #expect(vm.linkQualityColor == expected)
     }
 
+    // MARK: - Wi-Fi connection gate
+
+    @Test(
+        "isWifiConnection is true only when the connection rides Wi-Fi",
+        arguments: [
+            (NetworkStats.mockGoodWifiConnection, true),
+            (NetworkStats.mockGoodEthConnection, false),
+            (NetworkStats.mockConstrainedExpensiveCellConnection, true),   // hotspot over Wi-Fi
+            (NetworkStats.mockExpensiveCellConnection, false),             // hotspot over cable
+            (NetworkStats.mockDisconnected, false),
+        ]
+    )
+    func isWifiConnectionGate(netStats: NetworkStats, expected: Bool) {
+        let vm = NetStatsViewModel(netStats: netStats, privateIP: nil, publicIP: nil)
+        #expect(vm.isWifiConnection == expected)
+    }
+
     // MARK: - Initialization
 
     @Test("ViewModel stores IP addresses")

--- a/QuickNetStatsTests/NetworkDetailsManagerTests.swift
+++ b/QuickNetStatsTests/NetworkDetailsManagerTests.swift
@@ -5,6 +5,7 @@
 
 import Testing
 import Foundation
+import Combine
 @testable import QuickNetStats
 
 @Suite("NetworkDetailsManager", .serialized)
@@ -67,5 +68,36 @@ struct NetworkDetailsManagerTests {
         await manager.getAddresses()
 
         #expect(manager.ssid == "HomeNet")
+    }
+
+    @Test("observeConnectionChanges refetches addresses on a published change")
+    func observeRefetchesAddresses() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data("93.45.10.2".utf8))
+        }
+        let manager = NetworkDetailsManager(session: mockSession())
+
+        let subject = PassthroughSubject<NetworkStats, Never>()
+        manager.observeConnectionChanges(subject.eraseToAnyPublisher())
+        subject.send(.mockGoodEthConnection)
+
+        let populated = await eventually { manager.publicIP == "93.45.10.2" }
+        #expect(populated)
+    }
+
+    /// Polls `condition` until it is true or the timeout elapses, yielding the
+    /// main actor between checks so the observed refetch can complete.
+    @discardableResult
+    private func eventually(
+        timeout: Duration = .seconds(3),
+        _ condition: () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
     }
 }

--- a/QuickNetStatsTests/NetworkDetailsManagerTests.swift
+++ b/QuickNetStatsTests/NetworkDetailsManagerTests.swift
@@ -52,4 +52,20 @@ struct NetworkDetailsManagerTests {
 
         #expect(manager.publicIP == nil)
     }
+
+    @Test("getAddresses populates the SSID from the Wi-Fi reader")
+    func ssidFetched() async {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let manager = NetworkDetailsManager(
+            session: mockSession(),
+            wifiReader: MockWifiReader(result: nil, currentSSID: "HomeNet")
+        )
+        await manager.getAddresses()
+
+        #expect(manager.ssid == "HomeNet")
+    }
 }

--- a/QuickNetStatsTests/SettingsTests.swift
+++ b/QuickNetStatsTests/SettingsTests.swift
@@ -26,6 +26,66 @@ struct SettingsDefaultsTests {
 
         #expect(Settings().keepDetailsExpanded == false)
     }
+
+    @Test("interfaceRateUnit defaults to bits per second")
+    @MainActor
+    func interfaceRateUnitDefaultsToBits() {
+        let key = Settings.UserDefaultsKeys.interfaceRateUnit
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().interfaceRateUnit == .bitsPerSecond)
+    }
+
+    @Test("wifiRateUnit defaults to bits per second")
+    @MainActor
+    func wifiRateUnitDefaultsToBits() {
+        let key = Settings.UserDefaultsKeys.wifiRateUnit
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().wifiRateUnit == .bitsPerSecond)
+    }
+
+    @Test("liveRateUnit defaults to bytes per second")
+    @MainActor
+    func liveRateUnitDefaultsToBytes() {
+        let key = Settings.UserDefaultsKeys.liveRateUnit
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().liveRateUnit == .bytesPerSecond)
+    }
+
+    @Test("startLiveMonitoringOnOpen defaults to false")
+    @MainActor
+    func startLiveMonitoringOnOpenDefaultsToFalse() {
+        let key = Settings.UserDefaultsKeys.startLiveMonitoringOnOpen
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().startLiveMonitoringOnOpen == false)
+    }
 }
 
 @Suite("Settings Enums")

--- a/QuickNetStatsTests/SettingsTests.swift
+++ b/QuickNetStatsTests/SettingsTests.swift
@@ -86,6 +86,21 @@ struct SettingsDefaultsTests {
 
         #expect(Settings().startLiveMonitoringOnOpen == false)
     }
+
+    @Test("showNetworkNames defaults to false")
+    @MainActor
+    func showNetworkNamesDefaultsToFalse() {
+        let key = Settings.UserDefaultsKeys.showNetworkNames
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().showNetworkNames == false)
+    }
 }
 
 @Suite("Settings Enums")

--- a/QuickNetStatsTests/SettingsTests.swift
+++ b/QuickNetStatsTests/SettingsTests.swift
@@ -5,8 +5,28 @@
 //  Tests for Settings-related enums: raw values and initializers.
 //
 
+import Foundation
 import Testing
 @testable import QuickNetStats
+
+@Suite("Settings Defaults")
+struct SettingsDefaultsTests {
+
+    @Test("keepDetailsExpanded defaults to false")
+    @MainActor
+    func keepDetailsExpandedDefaultsToFalse() {
+        let key = Settings.UserDefaultsKeys.keepDetailsExpanded
+        let savedValue = UserDefaults.standard.object(forKey: key)
+        UserDefaults.standard.removeObject(forKey: key)
+        defer {
+            if let savedValue {
+                UserDefaults.standard.set(savedValue, forKey: key)
+            }
+        }
+
+        #expect(Settings().keepDetailsExpanded == false)
+    }
+}
 
 @Suite("Settings Enums")
 struct SettingsTests {

--- a/QuickNetStatsTests/SettingsViewModelTests.swift
+++ b/QuickNetStatsTests/SettingsViewModelTests.swift
@@ -19,6 +19,7 @@ struct SettingsViewModelTests {
         arguments: [
             (SettingsViewModel.SettingsPage.menubar, "Menu Bar"),
             (SettingsViewModel.SettingsPage.visuals, "Visuals"),
+            (SettingsViewModel.SettingsPage.connectionDetails, "Connection Details"),
             (SettingsViewModel.SettingsPage.notifications, "Notifications"),
             (SettingsViewModel.SettingsPage.about, "About"),
         ]
@@ -34,6 +35,7 @@ struct SettingsViewModelTests {
         arguments: [
             (SettingsViewModel.SettingsPage.menubar, "menubar.rectangle"),
             (SettingsViewModel.SettingsPage.visuals, "accessibility"),
+            (SettingsViewModel.SettingsPage.connectionDetails, "speedometer"),
             (SettingsViewModel.SettingsPage.notifications, "bell.badge"),
             (SettingsViewModel.SettingsPage.about, "info.circle"),
         ]
@@ -49,6 +51,7 @@ struct SettingsViewModelTests {
         arguments: [
             (SettingsViewModel.SettingsPage.menubar, Color.red),
             (SettingsViewModel.SettingsPage.visuals, Color.blue),
+            (SettingsViewModel.SettingsPage.connectionDetails, Color.orange),
             (SettingsViewModel.SettingsPage.notifications, Color.green),
             (SettingsViewModel.SettingsPage.about, Color.gray),
         ]
@@ -59,9 +62,9 @@ struct SettingsViewModelTests {
 
     // MARK: - CaseIterable & Identifiable
 
-    @Test("allCases contains exactly 4 pages")
+    @Test("allCases contains exactly 5 pages")
     func allCasesCount() {
-        #expect(SettingsViewModel.SettingsPage.allCases.count == 4)
+        #expect(SettingsViewModel.SettingsPage.allCases.count == 5)
     }
 
     @Test("id matches rawValue for each page")

--- a/QuickNetStatsTests/UpdateManagerTests.swift
+++ b/QuickNetStatsTests/UpdateManagerTests.swift
@@ -31,6 +31,7 @@ struct UpdateManagerTests {
             ("V2.3.0", "2.3.0"),
             ("2.3.0", "2.3.0"),
             ("V.2.2.0-Beta-1", "2.2.0-Beta-1"),
+            ("V.3.0.0-Beta-2", "3.0.0-Beta-2"),
         ]
     )
     func cleanVersionStripsPrefixes(tag: String, expected: String) {
@@ -45,6 +46,39 @@ struct UpdateManagerTests {
         #expect(manager.isVersion("2.3.0", newerThan: "2.2.0"))
         #expect(!manager.isVersion("2.2.0", newerThan: "2.2.0"))
         #expect(!manager.isVersion("2.1.9", newerThan: "2.2.0"))
+    }
+
+    @Test(
+        "isVersion handles pre-release suffixes",
+        arguments: [
+            // The stable release supersedes its own betas
+            ("3.0.0", "3.0.0-Beta-2", true),
+            // A beta is never newer than the stable release with the same base
+            ("3.0.0-Beta-2", "3.0.0", false),
+            // Different bases: the numeric base comparison decides, suffixes or not
+            ("3.1.0-Beta-1", "3.0.0", true),
+            ("3.0.0-Beta-1", "3.1.0", false),
+            // Two pre-releases with the same base are treated as equal
+            ("3.0.0-Beta-2", "3.0.0-Beta-1", false),
+        ]
+    )
+    func prereleaseComparison(remote: String, local: String, expected: Bool) {
+        let manager = UpdateManager(session: mockSession())
+        #expect(manager.isVersion(remote, newerThan: local) == expected)
+    }
+
+    // MARK: - Beta detection
+
+    @Test(
+        "isBetaVersion detects a beta suffix case-insensitively",
+        arguments: [
+            ("3.0.0-Beta-2", true),
+            ("3.0.0-beta-1", true),
+            ("3.0.0", false),
+        ]
+    )
+    func betaVersionDetection(version: String, expected: Bool) {
+        #expect(UpdateManager.isBetaVersion(version) == expected)
     }
 
     // MARK: - checkForUpdates

--- a/context/planning/add-connection-details-dropdown.md
+++ b/context/planning/add-connection-details-dropdown.md
@@ -1,0 +1,898 @@
+# Plan: Connection Details Dropdown
+
+> **Date**: 2026-07-04
+> **Scope**: A collapsible "Connection Details" section in the popover, below the public/private IP
+> buttons, showing advanced network information (router, DNS, subnet, MAC, IPv6, MTU, DHCP lease,
+> Wi-Fi RF stats) plus an opt-in Live section (RSSI/SNR/tx rate/throughput).
+> **Prerequisite**: None. Builds on the research inventory of obtainable network information
+> (free tier only — SSID/BSSID are location-gated and explicitly out of scope for now).
+
+---
+
+## Context
+
+QuickNetStats today shows connection type, link quality, and the two IP addresses. Power users
+want the "archaic" details — gateway, DNS servers, subnet mask, MAC address, MTU, DHCP lease,
+Wi-Fi channel/PHY/security, signal strength, live throughput.
+
+A research pass established that everything listed here is obtainable **with the current
+entitlements, sandbox-safe, and without any permission prompt**, from four sources:
+
+1. **SystemConfiguration** (already imported): router IP, primary interface, DNS servers, search
+   domains, subnet mask, DHCP lease times, hostname — via read-only `SCDynamicStore` `State:/` keys.
+2. **BSD layer** (`getifaddrs`, `sysctl`, `ioctl` — already partially used): MAC address, MTU,
+   IPv6 address, link speed, per-interface byte counters (→ throughput).
+3. **CoreWLAN** (new import, **not** location-gated for these fields): channel number/band/width,
+   PHY mode, security, country code, RSSI, noise, transmit rate. Only `ssid()`/`bssid()` are
+   location-gated, and those are deferred.
+4. **ipify** (existing pattern): public IPv6 via `api6.ipify.org`.
+
+Decisions taken during brainstorming:
+
+- **Approach A**: a new dedicated `ConnectionDetailsManager` (alongside the existing two managers),
+  publishing value-type snapshots; composed of small injectable readers.
+- **Layout**: grouped subsections, each rendered as a two-column grid.
+- **Live data**: a separate section at the bottom of the dropdown, grayed titles-only by default,
+  with a "Live" toggle button. Polling runs only while toggled on; closing the popover stops
+  polling and resets the button to "Live".
+- **Maximal inclusion**: prefer adding a field over debating it; fields can be removed later.
+
+---
+
+## Overview
+
+```
+QuickNetStatsApp
+ ├─ @StateObject NetworkStatsManager        (existing)
+ ├─ @StateObject NetworkDetailsManager      (existing)
+ ├─ @StateObject ConnectionDetailsManager   (NEW)
+ │        │
+ │        │ composes (injectable protocols)
+ │        ├─ SystemConfigReading  → SystemConfigReader   (SCDynamicStore)
+ │        ├─ InterfaceReading     → InterfaceReader      (getifaddrs / sysctl / ioctl)
+ │        ├─ WifiReading          → WifiReader           (CoreWLAN)
+ │        └─ URLSession           → public IPv6 (api6.ipify.org)
+ │
+ └─ ContentView
+     └─ NetStatsView
+         ├─ interface icon + link quality        (existing)
+         ├─ ipButtonsSection                     (existing)
+         ├─ ConnectionDetailsView                (NEW — the dropdown)
+         │    ├─ DetailGroupView "Interface"     (two-column Grid)
+         │    ├─ DetailGroupView "Addressing"
+         │    ├─ DetailGroupView "DNS & DHCP"
+         │    ├─ DetailGroupView "Wi-Fi"         (hidden on non-Wi-Fi)
+         │    └─ LiveStatsSectionView            (grayed → "Live" toggle → polling)
+         └─ exceptionDescriptionSection          (existing)
+
+Data flow:
+  expand dropdown ──► manager.fetchDetails() ──► @Published details: ConnectionDetails?
+  press "Live"    ──► manager.startLive()    ──► 1 s Task loop ──► @Published liveStats
+  press "Stop" / collapse / popover closes ──► manager.stopLive() ──► liveStats = nil
+  refresh button (existing) ──► manager.refresh() (re-fetch static details if present)
+```
+
+---
+
+## Design
+
+### Models (value types, `QuickNetStats/Models/`)
+
+**`ConnectionDetails.swift`** — one immutable snapshot, grouped to mirror the UI:
+
+- `InterfaceDetails`: `bsdName` (`en0`), `displayName` ("Wi-Fi"), `macAddress`, `mtu: Int?`,
+  `linkSpeedMbps: Double?`
+- `AddressingDetails`: `ipv6Address` (best local IPv6 — global unicast preferred, link-local
+  skipped), `publicIPv6`, `subnetMask`, `routerAddress`, `hostname`
+- `DnsDhcpDetails`: `dnsServers: [String]`, `searchDomains: [String]`, `dhcpLeaseExpiry: Date?`
+- `WifiDetails?` (nil on non-Wi-Fi): `channelNumber: Int`, `band` (2.4/5/6 GHz), `channelWidthMHz`,
+  `phyMode` ("802.11ax"), `security` ("WPA3 Personal"), `countryCode`
+
+All leaf fields optional; a nil field means "could not be determined" and its row is omitted.
+Static mocks (`mockWifi`, `mockEthernet`, `mockVPN`) for previews and tests, following the
+`NetworkStats` mock pattern.
+
+**`LiveConnectionStats.swift`** — one live sample:
+
+- `downloadBytesPerSec: Double?`, `uploadBytesPerSec: Double?` (any interface; nil until the
+  second poll tick, since throughput needs a counter delta)
+- `rssiDBm: Int?`, `noiseDBm: Int?`, `txRateMbps: Double?` (Wi-Fi only); computed `snrDB: Int?`
+
+Formatting lives with the models as computed properties / small helpers (e.g. "−52 dBm",
+"Channel 44 (5 GHz, 80 MHz)", "1.2 MB/s", lease expiry as short absolute date), so views stay dumb
+and formatting is unit-testable.
+
+### Readers (protocol seams, `QuickNetStats/Managers/`)
+
+Three small stateless readers, each behind a protocol so the manager is fully testable without
+touching real syscalls — the same seam pattern used by `UpdateManager(session:)` and
+`NetworkStatsManager(reachabilityChecker:)`:
+
+- **`SystemConfigReading` → `SystemConfigReader`**: one call returning a `SystemConfigSnapshot`
+  (primary interface BSD name, router IPv4, DNS servers, search domains, subnet mask for the
+  primary service, DHCP lease expiry via `SCDynamicStoreCopyDHCPInfo` +
+  `DHCPInfoGetLeaseStartTime`/option 51, local hostname).
+- **`InterfaceReading` → `InterfaceReader`**: `snapshot(for bsdName:)` returning MAC address
+  (`AF_LINK`), MTU (`if_data.ifi_mtu`), best local IPv6 (`AF_INET6`, global unicast preferred),
+  link speed (`ifi_baudrate`), and 64-bit rx/tx byte counters (`sysctl NET_RT_IFLIST2` /
+  `if_data64` — avoids 32-bit rollover).
+- **`WifiReading` → `WifiReader`**: `import CoreWLAN` (only file that imports it);
+  `CWWiFiClient.shared().interface()` → static snapshot (channel/band/width, PHY, security,
+  country) and RF sample (RSSI, noise, tx rate). Returns nil cleanly when there is no Wi-Fi
+  interface or Wi-Fi is off. **No SSID/BSSID calls anywhere.**
+
+Public IPv6 is not a reader: the manager fetches `https://api6.ipify.org` with an injectable
+`URLSession` (default `.reachabilitySession`), mirroring `NetworkDetailsManager`. Failure
+(common: no IPv6 connectivity) simply leaves the row out.
+
+### `ConnectionDetailsManager` (`QuickNetStats/Managers/`)
+
+`ObservableObject`, main-actor (project default isolation), created as a root-level `@StateObject`
+in `QuickNetStatsApp` alongside the other two managers.
+
+Published state:
+
+- `@Published private(set) var details: ConnectionDetails?` — nil until first expand
+- `@Published private(set) var liveStats: LiveConnectionStats?` — nil unless live
+- `@Published private(set) var isLive = false`
+
+API:
+
+- `fetchDetails() async` — SC snapshot → primary interface → interface snapshot → Wi-Fi snapshot;
+  public IPv6 fetched concurrently (`async let`); assembles and publishes `ConnectionDetails`.
+  Called on first expand and by `refresh()`.
+- `refresh() async` — re-fetches only if `details != nil` (i.e. the user has opened the dropdown
+  at least once); wired into the existing refresh button in `ContentView`.
+- `startLive()` / `stopLive()` — toggles a stored `Task` polling every `pollInterval` (default
+  1 s, injectable for tests): each tick reads byte counters + RF sample, computes throughput from
+  the previous tick's counters (`(now − prev) / elapsed`; negative delta → counter reset → skip),
+  publishes a new `LiveConnectionStats`. First tick publishes RF values with nil throughput.
+  `stopLive()` cancels the task, clears `liveStats`, sets `isLive = false`. Task body uses
+  `[weak self]` and honors cancellation (patterns from `NetworkStatsManager.pollingTask`).
+- `init(systemConfig: SystemConfigReading = SystemConfigReader(), interface: InterfaceReading =
+  InterfaceReader(), wifi: WifiReading = WifiReader(), session: URLSession = .reachabilitySession,
+  pollInterval: TimeInterval = 1.0)`
+
+The manager never throws to the UI: readers return optionals, and whatever is nil is simply absent
+from the snapshot.
+
+### Views (`QuickNetStats/Views/NetStatsView/` + `Views/Camponents/`)
+
+**`ConnectionDetailsView`** — owns the dropdown. Placed inside `NetStatsView.body` directly after
+`ipButtonsSection` (literally "below the IPs"), receiving the manager via `@ObservedObject`
+(passed down from `ContentView`, like the managers `ContentView` already receives).
+
+- Header: a plain-style `Button` ("Connection Details" + rotating chevron) toggling
+  `@State private var isExpanded` — custom expander rather than `DisclosureGroup`, whose default
+  macOS styling is list-oriented; rotation/expansion animated with `.animation(_:value:)` gated on
+  `settings.useAnimations` (existing accessibility-aware setting).
+- Expansion state is **not persisted**: fresh popover → collapsed.
+- On first expand: `task { await manager.fetchDetails() }`. While `details == nil` show a small
+  `ProgressView`.
+- On collapse and on `onDisappear` (popover closed): `manager.stopLive()`.
+- Hidden entirely when `netStats.isConnected == false`.
+
+**`DetailGroupView`** (Camponents) — reusable: caption (`.caption`, secondary) + `Grid` (macOS 13+)
+of label–value `GridRow`s. Labels secondary; values primary, monospaced digits. Each row is a
+plain-style `Button` that copies the raw value via the existing clipboard helper, with
+`.help("Click to copy")` — consistent with the IP buttons. Rows with nil values are omitted;
+a group with zero rows is not rendered. Row content drives Grid column sizing; long values (IPv6)
+get `.truncationMode(.middle)` + full value in `.help`.
+
+Groups and rows (maximal inclusion, top to bottom):
+
+| Group | Rows |
+|---|---|
+| Interface | Name ("Wi-Fi (en0)"), MAC address, MTU, Link speed |
+| Addressing | Router, Subnet mask, IPv6 (local), Public IPv6, Hostname |
+| DNS & DHCP | DNS servers (comma-joined), Search domains, DHCP lease expires |
+| Wi-Fi | Channel ("44 · 5 GHz · 80 MHz"), PHY mode, Security, Country code |
+
+**`LiveStatsSectionView`** (Camponents) — the Live section, always last:
+
+- Caption row: "Live" caption + trailing toggle `Button`: label "Live" (with `waveform` style
+  symbol) when idle, "Stop" when polling.
+- Body: same two-column grid; rows: Download, Upload (always), RSSI, Noise, SNR, Tx rate
+  (Wi-Fi only). When idle: titles visible, values rendered as "—", whole grid
+  `.foregroundStyle(.tertiary)` (the "grayed, titles only" state). When live: real values,
+  normal styling; a value momentarily unavailable stays "—".
+- Pressing Live → `manager.startLive()`; Stop → `manager.stopLive()`. No polling exists in any
+  other state.
+
+Previews: `ConnectionDetailsView` previews for Wi-Fi / Ethernet / VPN / loading / live states,
+driven by mock readers injected into a preview manager (`ConnectionDetailsManager.preview`
+static helpers), following the existing `NetworkStats.mock*` convention.
+
+### Wiring changes (existing files)
+
+- `QuickNetStatsApp`: third `@StateObject`, passed to `ContentView`.
+- `ContentView`: passes manager to `NetStatsView`; refresh button additionally calls
+  `await connectionDetailsManager.refresh()`.
+- `NetStatsView`: new init parameter (the manager), `ConnectionDetailsView` inserted after
+  `ipButtonsSection`. Existing previews updated with the preview manager.
+
+### Testing (Swift Testing, `QuickNetStatsTests/`)
+
+- **`ConnectionDetailsManagerTests`** (mock readers, injected fast `pollInterval`): fetch
+  assembles all groups; Wi-Fi group nil when wifi reader returns nil; public IPv6 fetched via
+  `MockURLProtocol` (existing token-based infrastructure) and absent on failure; `refresh()`
+  no-ops before first fetch; `startLive()` publishes RF on first tick and throughput from the
+  second; throughput delta math (fabricated counter sequences, including counter-reset → skipped
+  sample); `stopLive()` cancels, clears `liveStats`, resets `isLive`; deinit cancels the task.
+- **Formatting tests**: dBm/SNR strings, channel string, byte-rate formatting, lease-date
+  formatting, IPv6 preference order (global unicast over link-local).
+- **Reader smoke tests**: real `SystemConfigReader`/`InterfaceReader`/`WifiReader` calls return
+  without crashing; assertions lenient (no assumption of active Wi-Fi or IPv6) so they pass on CI.
+- No new singleton-bound state, so no additions to `SingletonBoundSuites`.
+
+---
+
+## Edge Cases & Constraints
+
+- **Ethernet**: Wi-Fi group hidden; Live section shows only Download/Upload.
+- **VPN as primary interface** (`utun*`): MAC, link speed, Wi-Fi rows unavailable → omitted;
+  router/DNS still shown. The dropdown describes the *primary* interface by design.
+- **Disconnected**: dropdown hidden entirely (IP buttons already communicate the state).
+- **Static-IP network**: no DHCP lease → row omitted. **No IPv6**: rows omitted.
+- **Multiple IPv6 addresses**: prefer global unicast, skip link-local (`fe80::/10`); deterministic
+  first match otherwise.
+- **Counter rollover / reset**: 64-bit counters via `NET_RT_IFLIST2`; negative deltas skipped.
+- **Popover lifecycle**: `onDisappear` is the stop signal for live polling. If the `.window`-style
+  `MenuBarExtra` proves not to fire it reliably, fall back to observing
+  `NSWindow.willCloseNotification` — verify during implementation.
+- **Energy**: zero cost while collapsed or closed; while live, one syscall batch + CoreWLAN read
+  per second, stopped the moment the popover closes.
+- **macOS 13 target**: everything used is 13-safe (`Grid` 13+, CoreWLAN 10.7+, `getifaddrs`/
+  `sysctl` POSIX). No `onChange` (two-parameter form is 14+); lifecycle handled via button
+  actions, `.task`, `onDisappear`. No new entitlements; all reads sandbox-safe.
+- **Future-proofing caveat**: Apple has historically widened Wi-Fi privacy redaction. If a future
+  macOS gates the RF fields, the rows silently degrade to omitted — no crash path.
+- **Out of scope**: SSID/BSSID (location-gated — separate future plan), a Settings toggle to hide
+  the section, throughput history/graphs, per-interface selection UI.
+- **Agreed follow-up (post-feature)**: rows omitted for nil values should eventually explain
+  *why* they are missing (e.g. "No DHCP lease — static IP") instead of disappearing silently.
+  To be designed and added once this feature has landed.
+
+---
+
+## Implementation Plan
+
+> **For agentic workers:** Execute task-by-task with TDD (superpowers:test-driven-development).
+> Check each `- [x]` box immediately upon completing the step. Invoke
+> `swift-testing-expert:swift-testing-expert` before writing test files and
+> `swiftui-expert:swiftui-expert-skill` before the view tasks (CLAUDE.md requirement).
+
+**Goal:** Ship the Connection Details dropdown described in the design above.
+
+**Architecture:** New value models + three injectable readers + `ConnectionDetailsManager`
++ three new views, wired into the existing app scaffolding. TDD for all logic; previews + build
+verification for views.
+
+### Global Constraints
+
+- macOS 13.0 deployment target; `#available` guards only where APIs demand it (none expected).
+- `ObservableObject`/`@Published` (NOT `@Observable` — that's macOS 14+). No `onChange` with the
+  two-parameter closure (14+). Project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
+- Swift Testing (`import Testing`, `#expect`) — never XCTest.
+- **Never call `ssid()` or `bssid()`** on `CWInterface` — location-gated, out of scope.
+- No new entitlements, no `Date.now`-dependent formatting assertions (locale/time-fragile tests
+  assert non-nil instead of exact strings where locale-dependent).
+- The Xcode project uses filesystem-synchronized groups: **new files on disk under
+  `QuickNetStats/` or `QuickNetStatsTests/` join their targets automatically — do not edit
+  `project.pbxproj`.** Note the intentional "Camponents" spelling.
+- **NEVER commit** — the user commits explicitly (CLAUDE.md Git Policy). Branch is already
+  `feat/detailed-info-dropdown`.
+- Build/test via the Xcode MCP bridge helper (Xcode must stay open on the project;
+  `tabIdentifier` is `windowtab1`):
+  ```bash
+  # Build
+  python3 /Users/federicoimberti/.claude/jobs/6e62f175/tmp/xcode_mcp.py call BuildProject '{"tabIdentifier":"windowtab1"}'
+  # All tests (fast, ~30 s for 110 tests)
+  python3 /Users/federicoimberti/.claude/jobs/6e62f175/tmp/xcode_mcp.py call RunAllTests '{"tabIdentifier":"windowtab1"}'
+  ```
+  CLI fallback if the bridge fails:
+  ```bash
+  env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer xcodebuild test \
+    -project QuickNetStats.xcodeproj -scheme QuickNetStats -destination 'platform=macOS'
+  ```
+- SourceKit "No such module 'Testing'" diagnostics in the editor are stale-indexer noise; trust
+  the build/test runs only.
+- Lint at the end: `env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer swiftlint lint`
+  (config `.swiftlint.yml`; `trailing_whitespace`/`opening_brace` disabled).
+
+### Task 1: `ConnectionDetails` model, rows, formatting
+
+**Files:**
+- Create: `QuickNetStats/Models/ConnectionDetails.swift`
+- Test: `QuickNetStatsTests/ConnectionDetailsTests.swift`
+
+**Produces (later tasks consume exactly these):**
+
+```swift
+struct DetailRow: Identifiable, Equatable {
+    let label: String
+    let value: String
+    var id: String { label }
+}
+
+struct ConnectionDetails: Equatable {
+    struct Interface: Equatable {
+        var bsdName: String?
+        var displayName: String?
+        var macAddress: String?
+        var mtu: Int?
+        var linkSpeedMbps: Double?
+    }
+    struct Addressing: Equatable {
+        var ipv6Address: String?
+        var publicIPv6: String?
+        var subnetMask: String?
+        var routerAddress: String?
+        var hostname: String?
+    }
+    struct DnsDhcp: Equatable {
+        var dnsServers: [String] = []
+        var searchDomains: [String] = []
+        var dhcpLeaseExpiry: Date?
+    }
+    struct Wifi: Equatable {
+        var channelNumber: Int?
+        var band: String?          // "2.4 GHz" | "5 GHz" | "6 GHz"
+        var channelWidthMHz: Int?
+        var phyMode: String?       // "802.11ax"
+        var security: String?      // "WPA3 Personal"
+        var countryCode: String?
+    }
+    var interface: Interface
+    var addressing: Addressing
+    var dnsDhcp: DnsDhcp
+    var wifi: Wifi?
+
+    var interfaceRows: [DetailRow]   // nil fields omitted
+    var addressingRows: [DetailRow]
+    var dnsDhcpRows: [DetailRow]
+    var wifiRows: [DetailRow]        // [] when wifi == nil
+
+    static let mockWifi: ConnectionDetails      // fully populated, wifi != nil
+    static let mockEthernet: ConnectionDetails  // wifi == nil, link speed 1000
+    static let mockVPN: ConnectionDetails       // only router/DNS/hostname populated
+}
+```
+
+Row content rules (test each):
+- Interface "Name": `displayName (bsdName)` → "Wi-Fi (en0)"; only one present → that one; both nil → row omitted.
+- "Link speed": `< 1000` → "866 Mbps" (no decimals); `>= 1000` → "1 Gbps"/"2.5 Gbps" (trailing `.0` stripped). From `linkSpeedMbps`.
+- "Channel": "44 · 5 GHz · 80 MHz" — pieces with nil dropped ("44 · 5 GHz" if width nil); all nil → row omitted.
+- "DNS servers"/"Search domains": comma-joined; empty array → row omitted.
+- "DHCP lease expires": `dhcpLeaseExpiry.formatted(date: .abbreviated, time: .shortened)` — test asserts row present for a date, absent for nil (no exact-string assert; locale-dependent).
+- Rows keep design order (see table in Design). Empty group → `[]`.
+
+- [x] **Step 1**: Invoke swift-testing-expert skill, then write `ConnectionDetailsTests` covering: each group's nil-omission per row, name-row composition (3 variants), link-speed formatting ("866 Mbps", "1 Gbps", "2.5 Gbps"), channel-text composition (full, partial, omitted), DNS join, `wifiRows` empty when `wifi == nil`, mocks non-empty.
+- [x] **Step 2**: Run tests → expect **compile failure** (types don't exist) via RunAllTests.
+- [x] **Step 3**: Implement `ConnectionDetails.swift` (model + row builders + private formatters + mocks).
+- [x] **Step 4**: RunAllTests → all pass (110 + new).
+
+### Task 2: `LiveConnectionStats` model + rate formatting
+
+**Files:**
+- Create: `QuickNetStats/Models/LiveConnectionStats.swift`
+- Test: `QuickNetStatsTests/LiveConnectionStatsTests.swift`
+
+**Produces:**
+
+```swift
+struct LiveConnectionStats: Equatable {
+    var downloadBytesPerSec: Double?
+    var uploadBytesPerSec: Double?
+    var rssiDBm: Int?
+    var noiseDBm: Int?
+    var txRateMbps: Double?
+
+    var snrDB: Int? // rssi − noise when both present
+    var rssiText: String?      // "-52 dBm"
+    var noiseText: String?     // "-95 dBm"
+    var snrText: String?       // "43 dB"
+    var txRateText: String?    // "866 Mbps" (reuse Task 1 formatter — make it internal static)
+    var downloadText: String?  // via rateText
+    var uploadText: String?
+
+    static func rateText(_ bytesPerSec: Double) -> String
+    // < 1_000 → "999 B/s"; < 1_000_000 → "12.3 KB/s"; < 1_000_000_000 → "1.2 MB/s"; else "1.2 GB/s"
+    // one decimal for KB and above, no decimals for B/s; deterministic (no locale formatter)
+
+    static let mockLiveWifi: LiveConnectionStats   // all fields
+    static let mockLiveWired: LiveConnectionStats  // throughput only
+}
+```
+
+- [x] **Step 1**: Write failing tests: `snrDB` math (−52, −95 → 43; nil when either missing), each `*Text` (exact strings — deterministic formatter), `rateText` at boundaries (999, 1_000, 999_999, 1_000_000, 1_500_000_000), mocks.
+- [x] **Step 2**: RunAllTests → compile failure.
+- [x] **Step 3**: Implement.
+- [x] **Step 4**: RunAllTests → green.
+
+### Task 3: `SystemConfigReader`
+
+**Files:**
+- Create: `QuickNetStats/Managers/SystemConfigReader.swift`
+- Test: `QuickNetStatsTests/ConnectionReadersTests.swift` (shared by Tasks 3–5)
+
+**Produces:**
+
+```swift
+struct SystemConfigSnapshot: Equatable {
+    var primaryInterface: String?
+    var primaryInterfaceDisplayName: String?
+    var primaryService: String?
+    var routerAddress: String?
+    var dnsServers: [String] = []
+    var searchDomains: [String] = []
+    var subnetMask: String?
+    var dhcpLeaseExpiry: Date?
+    var hostname: String?
+}
+protocol SystemConfigReading { func snapshot() -> SystemConfigSnapshot }
+struct SystemConfigReader: SystemConfigReading { ... }
+```
+
+Implementation (SCDynamicStore reads, all optional-safe):
+- `SCDynamicStoreCreate(nil, "QuickNetStats" as CFString, nil, nil)`
+- `State:/Network/Global/IPv4` → `Router`, `PrimaryInterface`, `PrimaryService`
+- `State:/Network/Global/DNS` → `ServerAddresses`, `SearchDomains`
+- `State:/Network/Service/<PrimaryService>/IPv4` → `SubnetMasks.first`
+- `SCDynamicStoreCopyDHCPInfo(store, service as CFString)` → prefer
+  `DHCPInfoGetLeaseExpirationTime`; if that symbol is unavailable in the SDK, compute
+  `DHCPInfoGetLeaseStartTime` + option 51 (`DHCPInfoGetOptionData(info, 51)`, 4-byte big-endian
+  seconds). Verify against a real run.
+- `SCDynamicStoreCopyLocalHostName(store)` → hostname
+- Display name: `SCNetworkInterfaceCopyAll()`, match `SCNetworkInterfaceGetBSDName` ==
+  primaryInterface → `SCNetworkInterfaceGetLocalizedDisplayName`.
+
+- [x] **Step 1**: Write lenient smoke tests: `snapshot()` returns without crashing; on a connected machine (`NWPathMonitor` not consulted — just assert types) `dnsServers` is an array (may be empty on CI), no force-unwraps reachable. If `primaryInterface != nil`, it matches `^[a-z]+[0-9]+$`.
+- [x] **Step 2**: RunAllTests → compile failure.
+- [x] **Step 3**: Implement.
+- [x] **Step 4**: RunAllTests → green. Manually eyeball one real snapshot via a debug `print` in test output (then remove the print).
+
+### Task 4: `InterfaceReader`
+
+**Files:**
+- Create: `QuickNetStats/Managers/InterfaceReader.swift`
+- Test: extend `QuickNetStatsTests/ConnectionReadersTests.swift`
+
+**Produces:**
+
+```swift
+struct InterfaceSnapshot: Equatable {
+    var macAddress: String?      // "aa:bb:cc:dd:ee:ff"
+    var mtu: Int?
+    var ipv6Address: String?
+    var linkSpeedMbps: Double?
+    var rxBytes: UInt64?
+    var txBytes: UInt64?
+}
+protocol InterfaceReading { func snapshot(for bsdName: String) -> InterfaceSnapshot }
+struct InterfaceReader: InterfaceReading {
+    static func preferredIPv6(from candidates: [String]) -> String?
+}
+```
+
+Implementation notes:
+- One `getifaddrs` pass filtered to `bsdName`:
+  - `AF_LINK` → `sockaddr_dl` (`withMemoryRebound`) → MAC bytes formatted `%02x:` joined; and
+    `ifa_data as if_data` → `ifi_mtu`, `ifi_baudrate` (baud > 0 → `/1_000_000` Mbps).
+  - `AF_INET6` → `getnameinfo(NI_NUMERICHOST)` (same pattern as
+    `NetworkDetailsManager.getPrivateIPAddress`), strip any `%scope` suffix, collect candidates.
+- `preferredIPv6` (pure, TDD): global unicast first (not `fe80`-prefixed, not `fc`/`fd`), else
+  ULA (`fc`/`fd`), never link-local. Case-insensitive.
+- Counters: `sysctl` MIB `[CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0]`, walk `if_msghdr`
+  records by `ifm_msglen`, on `ifm_type == RTM_IFINFO2` decode `if_msghdr2`
+  (use `loadUnaligned`), match `ifm_index == if_nametoindex(bsdName)` →
+  `ifm_data.ifi_ibytes` / `ifi_obytes` (64-bit).
+
+- [x] **Step 1**: Write failing tests — `preferredIPv6`: `(["fe80::1", "2a00:1::2", "fd12::1"]) == "2a00:1::2"`, `(["fe80::1", "fd12::1"]) == "fd12::1"`, `(["FE80::1"]) == nil`, `([]) == nil`. Smoke: `snapshot(for: "lo0")` doesn't crash and `mtu != nil`; `snapshot(for: "definitely-not-real99")` returns all-nil snapshot; if the machine has an `en0`, counters are non-nil.
+- [x] **Step 2**: RunAllTests → compile failure.
+- [x] **Step 3**: Implement.
+- [x] **Step 4**: RunAllTests → green.
+
+### Task 5: `WifiReader`
+
+**Files:**
+- Create: `QuickNetStats/Managers/WifiReader.swift` (the ONLY file importing CoreWLAN)
+- Test: extend `QuickNetStatsTests/ConnectionReadersTests.swift`
+
+**Produces:**
+
+```swift
+struct WifiSnapshot: Equatable {
+    var channelNumber: Int?
+    var band: String?
+    var channelWidthMHz: Int?
+    var phyMode: String?
+    var security: String?
+    var countryCode: String?
+    var rssiDBm: Int?
+    var noiseDBm: Int?
+    var txRateMbps: Double?
+}
+protocol WifiReading { func snapshot(for bsdName: String) -> WifiSnapshot? }
+struct WifiReader: WifiReading { ... }
+```
+
+Implementation notes:
+- `CWWiFiClient.shared().interface(withName: bsdName)` — nil (non-Wi-Fi BSD name / no Wi-Fi) → return nil. **Never touch `ssid()`/`bssid()`.**
+- `wlanChannel()` → number; band switch (`.band2GHz`→"2.4 GHz", `.band5GHz`→"5 GHz", `.band6GHz`→"6 GHz"); width switch (20/40/80/160 MHz), `@unknown default` → nil.
+- `activePHYMode()` switch → "802.11a/b/g/n/ac/ax"; `.none`/unknown → nil.
+- `security()` switch → "Open", "WEP", "WPA Personal", "WPA2 Personal", "WPA3 Personal", "WPA2/WPA3 Personal" (transition), enterprise variants, unknown → nil.
+- `rssiValue()`/`noiseMeasurement()` return 0 when unavailable → map 0 to nil; `transmitRate()` ≤ 0 → nil.
+
+- [x] **Step 1**: Write lenient smoke tests: `snapshot(for: "lo0") == nil`; on this machine `snapshot(for: "en0")` (Wi-Fi here) either nil (Wi-Fi off) or has `rssiDBm` in −100...0 when non-nil. Grep-style guard test: source of `WifiReader.swift` contains neither `ssid(` nor `bssid(` (read file from `#filePath`-relative path… if fragile, drop this and rely on review).
+- [x] **Step 2**: RunAllTests → compile failure.
+- [x] **Step 3**: Implement.
+- [x] **Step 4**: RunAllTests → green.
+
+### Task 6: `ConnectionDetailsManager` — fetch path
+
+**Files:**
+- Create: `QuickNetStats/Managers/ConnectionDetailsManager.swift`
+- Test: `QuickNetStatsTests/ConnectionDetailsManagerTests.swift`
+
+**Consumes:** all three protocols + snapshots (Tasks 3–5), models (Tasks 1–2).
+**Produces:**
+
+```swift
+class ConnectionDetailsManager: ObservableObject {
+    @Published private(set) var details: ConnectionDetails?
+    @Published private(set) var liveStats: LiveConnectionStats?
+    @Published private(set) var isLive = false
+
+    init(systemConfig: SystemConfigReading = SystemConfigReader(),
+         interfaceReader: InterfaceReading = InterfaceReader(),
+         wifiReader: WifiReading = WifiReader(),
+         session: URLSession = .reachabilitySession,
+         pollInterval: TimeInterval = 1.0)
+
+    func fetchDetails() async
+    func refresh() async          // no-op when details == nil
+    func startLive()
+    func stopLive()
+    static func bytesPerSecond(previous: UInt64, current: UInt64, elapsed: TimeInterval) -> Double?
+}
+```
+
+Fetch assembly: `systemConfig.snapshot()` → primary BSD name → `interfaceReader.snapshot(for:)`
++ `wifiReader.snapshot(for:)` (nil ⇒ `wifi` group nil); `async let` public IPv6 from
+`https://api6.ipify.org` (2xx + response body contains ":" else nil — mirror
+`NetworkDetailsManager.fetchPublicIpAddress` incl. the status-code guard); assemble
+`ConnectionDetails` and publish once at the end. No primary interface ⇒ still publish
+(router/DNS/hostname may exist; interface group rows mostly omitted).
+
+Test doubles (in the test file): `MockSystemConfigReader`/`MockInterfaceReader`/`MockWifiReader`
+structs wrapping stub snapshots, plus `MockURLProtocol` sessions — copy the private
+`mockSession()` helper pattern from `NetworkDetailsManagerTests` (token-keyed handlers already
+exist in the shared `MockURLProtocol`).
+
+- [x] **Step 1**: Invoke swift-testing-expert (if context lost), write failing tests: fetch assembles all four groups from stubs; wifi reader nil → `details?.wifi == nil`; ipify 200 "2a00::1" → `publicIPv6 == "2a00::1"`; ipify 500 or error → nil; response without ":" → nil; no primary interface → details still published with router/DNS; `refresh()` before any fetch → `details` stays nil (stub readers record zero calls); `refresh()` after fetch → readers called again.
+- [x] **Step 2**: RunAllTests → compile failure.
+- [x] **Step 3**: Implement fetch path only (`startLive`/`stopLive` empty stubs, `bytesPerSecond` unimplemented `nil`).
+- [x] **Step 4**: RunAllTests → green (live tests come next task).
+
+### Task 7: `ConnectionDetailsManager` — live polling
+
+**Files:**
+- Modify: `QuickNetStats/Managers/ConnectionDetailsManager.swift`
+- Test: extend `QuickNetStatsTests/ConnectionDetailsManagerTests.swift`
+
+Implementation:
+- `bytesPerSecond`: `elapsed > 0 && current >= previous` else nil; `Double(current - previous) / elapsed`.
+- Private `previousSample: (rx: UInt64, tx: UInt64, at: Date)?`, cleared by `startLive()` and `stopLive()`.
+- `startLive()`: guard `!isLive`; `isLive = true`; store `liveTask = Task { [weak self] in while !Task.isCancelled { guard let self else { return }; self.tick(); try? await Task.sleep(for: .seconds(self.pollInterval)) } }` (pattern from `NetworkStatsManager` polling).
+- `tick()`: guard `let bsd = details?.interface.bsdName` else return; read interface + wifi snapshots; throughput from `previousSample` via `bytesPerSecond` (nil on first tick); update `previousSample`; publish `LiveConnectionStats` (RF fields straight from wifi snapshot).
+- `stopLive()`: cancel + nil task, `isLive = false`, `liveStats = nil`, `previousSample = nil`.
+- `deinit`: `liveTask?.cancel()`.
+
+- [x] **Step 1**: Write failing tests (inject `pollInterval: 0.05`; reuse/introduce a small
+  `eventually(timeout:condition:)` async helper — check `NetworkStatsManagerTests` for an
+  existing one first):
+  - `bytesPerSecond` math: `(1_000, 3_000, 2.0) == 1_000`; negative delta → nil; `elapsed 0` → nil.
+  - After fetch + `startLive()`: eventually `liveStats?.rssiDBm == stub value`; eventually (second tick, counters stub +1_000 per call via a mutating stub) `downloadBytesPerSec != nil`.
+  - First tick: `downloadBytesPerSec == nil` while `rssiDBm != nil`.
+  - `startLive()` without fetch → no crash, `liveStats` stays nil-throughput (tick guards).
+  - `stopLive()` → `isLive == false`, `liveStats == nil`; double `startLive()` doesn't stack tasks (poll count from stub call-counting stays plausible).
+- [x] **Step 2**: RunAllTests → failures on new tests.
+- [x] **Step 3**: Implement.
+- [x] **Step 4**: RunAllTests → green.
+
+### Task 8: `DetailGroupView`
+
+**Files:**
+- Create: `QuickNetStats/Views/Camponents/DetailGroupView.swift`
+
+**Consumes:** `DetailRow` (Task 1).
+
+- [x] **Step 1**: Invoke swiftui-expert skill (if context lost). Implement:
+
+```swift
+struct DetailGroupView: View {
+    let title: String
+    let rows: [DetailRow]
+
+    var body: some View {
+        if !rows.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 4) {
+                    ForEach(rows) { row in
+                        GridRow {
+                            Text(row.label)
+                                .foregroundStyle(.secondary)
+                                .gridColumnAlignment(.leading)
+                            Button {
+                                let pasteboard = NSPasteboard.general
+                                pasteboard.clearContents()
+                                pasteboard.setString(row.value, forType: .string)
+                            } label: {
+                                Text(row.value)
+                                    .monospacedDigit()
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                            .buttonStyle(.plain)
+                            .help("Click to copy")
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+```
+
+  Previews: one populated group (use `ConnectionDetails.mockWifi.interfaceRows`), one empty
+  (renders nothing), one with a long IPv6 value (truncation visible).
+- [x] **Step 2**: BuildProject → succeeds; visually check previews render (RenderPreview via
+  bridge if convenient, else rely on build + later manual run).
+
+### Task 9: `LiveStatsSectionView`
+
+**Files:**
+- Create: `QuickNetStats/Views/Camponents/LiveStatsSectionView.swift`
+
+**Consumes:** `LiveConnectionStats` (Task 2).
+
+- [x] **Step 1**: Implement. Inputs: `let isLive: Bool`, `let showsWifiRows: Bool`,
+  `let stats: LiveConnectionStats?`, `let onToggle: () -> Void`. Layout: caption row
+  (`Text("Live")` caption style + `Spacer` + toggle `Button(isLive ? "Stop" : "Live")` with
+  `waveform`-family SF Symbol, `.buttonStyle(.plain)`, `.focusable(false)`); then the same
+  `Grid` shape as `DetailGroupView` with fixed rows: Download, Upload always; RSSI, Noise, SNR,
+  Tx rate when `showsWifiRows`. Values: when `!isLive` → "—" for all and the whole grid
+  `.foregroundStyle(.tertiary)`; when live → `stats?.downloadText ?? "—"` etc. Live rows are
+  NOT copy buttons (values churn every second) — plain `Text`.
+  Previews: idle wifi, live wifi (`mockLiveWifi`), live wired (`mockLiveWired`, no RF rows).
+- [x] **Step 2**: BuildProject → succeeds.
+
+### Task 10: `ConnectionDetailsView` + wiring
+
+**Files:**
+- Create: `QuickNetStats/Views/NetStatsView/ConnectionDetailsView.swift`
+- Modify: `QuickNetStats/QuickNetStatsApp.swift` (third `@StateObject`, pass to `ContentView`)
+- Modify: `QuickNetStats/Views/ContentView.swift` (accept + forward manager; refresh button adds `await connectionDetailsManager.refresh()`)
+- Modify: `QuickNetStats/Views/NetStatsView/NetStatsView.swift` (accept manager, insert view after `ipButtonsSection` inside the `if vm.netStats.isConnected` gate — add that gate around the new view only; update ALL previews)
+
+**Consumes:** manager (Tasks 6–7), views (Tasks 8–9).
+
+- [x] **Step 1**: Implement `ConnectionDetailsView`:
+
+```swift
+struct ConnectionDetailsView: View {
+    @ObservedObject var manager: ConnectionDetailsManager
+    @EnvironmentObject var settings: Settings
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                isExpanded.toggle()
+                if !isExpanded { manager.stopLive() }
+            } label: {
+                HStack(spacing: 6) {
+                    Text("Connection Details")
+                    Image(systemName: "chevron.right")
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .focusable(false)
+
+            if isExpanded {
+                if let details = manager.details {
+                    DetailGroupView(title: "Interface", rows: details.interfaceRows)
+                    DetailGroupView(title: "Addressing", rows: details.addressingRows)
+                    DetailGroupView(title: "DNS & DHCP", rows: details.dnsDhcpRows)
+                    DetailGroupView(title: "Wi-Fi", rows: details.wifiRows)
+                    LiveStatsSectionView(
+                        isLive: manager.isLive,
+                        showsWifiRows: details.wifi != nil,
+                        stats: manager.liveStats,
+                        onToggle: { manager.isLive ? manager.stopLive() : manager.startLive() }
+                    )
+                } else {
+                    ProgressView().controlSize(.small)
+                }
+            }
+        }
+        .animation(settings.useAnimations ? .default : nil, value: isExpanded)
+        .task(id: isExpanded) {
+            if isExpanded && manager.details == nil { await manager.fetchDetails() }
+        }
+        .onDisappear { manager.stopLive() }
+    }
+}
+```
+
+  Verify during implementation that `onDisappear` fires when the `.window` MenuBarExtra closes
+  (log once, run app); if it does not, observe `NSWindow.willCloseNotification` instead — note
+  outcome in this file.
+  Previews for `ConnectionDetailsView` and updated `NetStatsView` previews: build a
+  `ConnectionDetailsManager.preview(details:)` static in an `#if DEBUG` extension (stub readers
+  returning mock-derived snapshots) — follow `NetworkStats.mock*` naming conventions.
+- [x] **Step 2**: BuildProject → succeeds.
+- [x] **Step 3**: RunAllTests → full suite green.
+- [x] **Step 4**: Launch the app (Debug build product via `open`), manually verify: expand →
+  values appear; press Live → values tick; close popover → reopen → collapsed and idle;
+  Ethernet/Wi-Fi variants as available; refresh button re-fetches. Report observations.
+  (See Implementation Notes — headless environment blocked interactive verification.)
+
+### Task 11: Final verification
+
+- [x] **Step 1**: `swiftlint lint` (with `DEVELOPER_DIR`) → 0 violations (run `--fix` first if needed).
+- [x] **Step 2**: RunAllTests → full suite green; BuildProject Release config not required (CI covers release at tag time).
+- [x] **Step 3**: Re-read this plan's Design section and confirm every group/row/behavior is
+  implemented or explicitly noted; update checkboxes; list any deviations at the end of this file.
+- [x] **Step 4**: Code-review checkpoint — performed from the main session (subagent dispatch),
+  not by the implementing agent. Verdict 2026-07-04: *ready to merge with fixes* — no Critical
+  findings; the two Important findings plus one recommended Minor were fixed and re-verified
+  (167/167 tests, lint 0). See "Code-review fixes" in the Implementation Notes below.
+
+---
+
+## Implementation Notes (deviations & observations)
+
+### Task 3 — SystemConfigReader
+
+- **DHCP lease API:** `DHCPInfoGetLeaseExpirationTime` compiled cleanly (macOS 10.8+), returning a
+  `CFDate?` that bridges directly to `Date?` (CF implicit bridging is enabled in the header). The
+  option-51 fallback described in the plan was **not needed**.
+- **Required submodule import:** `SCDynamicStoreCopyDHCPInfo` / `DHCPInfoGetLeaseExpirationTime`
+  are NOT re-exported by the `SystemConfiguration` umbrella. They live in an explicit submodule and
+  need `import SystemConfiguration.SCDynamicStoreCopyDHCPInfo` — a plain `import SystemConfiguration`
+  gives "Cannot find 'SCDynamicStoreCopyDHCPInfo' in scope".
+- **Real-machine snapshot (this dev machine):** primaryInterface `en1`, displayName "Wi-Fi",
+  router `10.0.0.1`, DNS `["100.100.100.100", "fd7a:115c:a1e0::53"]` (Tailscale MagicDNS active),
+  searchDomains `["dhole-tritone.ts.net"]`, subnetMask `255.255.255.0`, hostname "Eurydice".
+  `dhcpLeaseExpiry` was **nil** here (network/Tailscale doesn't expose a lease on the primary
+  service) — confirms the nil-lease → row-omitted path works without crashing. Note the primary
+  interface is `en1` (not `en0`) on this machine because of an active VPN/Tailscale setup.
+
+### Task 4 — InterfaceReader
+
+- `MemoryLayout<sockaddr_dl>.offset(of: \.sdl_data)` compiles and returns a valid offset, so the
+  MAC address is read from the raw allocation rather than trusting the declared 12-byte `sdl_data`
+  tuple size (robust for interface names of any length).
+- `UnsafeRawPointer.loadUnaligned(as:)` is available on the macOS 13 target (Swift stdlib 5.7) and
+  is used to walk the `NET_RT_IFLIST2` `if_msghdr`/`if_msghdr2` records.
+- `lo0` reports MTU and non-nil 64-bit byte counters (loopback has an IFLIST2 record); a bogus
+  interface name yields an all-nil `InterfaceSnapshot` (index lookup + getifaddrs both miss).
+
+### Task 5 — WifiReader
+
+- **CoreWLAN enum mapping via `rawValue`, not case names.** The Swift-imported `CWSecurity` cases
+  have fragile acronym casing (`.WEP`, `.OWE` vs `.wpaPersonal`), so all four enums (`CWChannelBand`,
+  `CWChannelWidth`, `CWPHYMode`, `CWSecurity`) are mapped by their documented, ABI-stable integer
+  raw values with a `default: nil` catch-all. This compiled first try and needs no extra enum-case
+  mapping. `CWSecurity` includes `Personal` (5), `Enterprise` (10), and the `WPA3Transition` (13,
+  shown as "WPA2/WPA3 Personal") and OWE (14/15) cases; `kCWSecurityUnknown` (NSIntegerMax) → nil.
+- Interface accessors are methods in Swift: `wlanChannel()`, `activePHYMode()`, `security()`,
+  `rssiValue()`, `noiseMeasurement()`, `transmitRate()`, `countryCode()`; `CWChannel.channelBand`
+  /`.channelWidth`/`.channelNumber` are properties. **No `ssid()`/`bssid()` calls anywhere.**
+
+### Tasks 6–7 — ConnectionDetailsManager
+
+- `async let publicIPv6 = fetchPublicIPv6()` compiles under `SWIFT_DEFAULT_ACTOR_ISOLATION =
+  MainActor`; the local (synchronous) reader calls run on the main actor and the network I/O
+  overlaps at the `await`. Public IPv6 guard mirrors `NetworkDetailsManager`: 2xx status AND the
+  body must contain a colon, else nil.
+- `deinit { liveTask?.cancel() }` compiles fine accessing the main-actor stored property — same
+  pattern the existing `NetworkStatsManager.deinit` already uses (approachable-concurrency /
+  isolated deinit is permitted in this project).
+- The poll loop mirrors `NetworkStatsManager.pollingTask`: `Task { [weak self] in while
+  !Task.isCancelled { guard let self else { return }; self.tick(); try? await Task.sleep(...) } }`.
+  First tick fires immediately (RF only, `previousSample == nil` → nil throughput); throughput
+  appears from the second tick. `startLive()` is guarded by `!isLive` so a double call cannot stack
+  a second loop.
+- Live tests use a private `eventually(timeout:_:)` main-actor helper (10 ms poll, 3 s default
+  timeout) — no existing async-wait helper was found in `NetworkStatsManagerTests` (those tests are
+  synchronous), so this one was introduced. The `MockInterfaceReader.incrementPerCall` knob grows
+  the byte counters each call to drive a deterministic positive throughput delta.
+
+### Task 10 — ConnectionDetailsView, wiring, and manual-run limitation
+
+- Wiring completed: `QuickNetStatsApp` owns a third `@StateObject connectionDetailsManager`, passed
+  through `ContentView` → `NetStatsView`; the refresh button now also `await`s
+  `connectionDetailsManager.refresh()` (a no-op until the dropdown has been opened once). The
+  dropdown is gated by `if vm.netStats.isConnected` inside `NetStatsView.body`, directly after
+  `ipButtonsSection`. All `NetStatsView` previews were updated with the new required parameter via
+  a new `#if DEBUG ConnectionDetailsManager.preview(details:isLive:liveStats:)` factory (sets the
+  private(set) published state directly from the same file; readers never run in previews).
+- **`onDisappear` NOT verified at runtime.** The build environment is headless: the app launches
+  cleanly (Debug product, bundle id `com.federicoimberti.quicknetstats.dev`, process stays alive),
+  but macOS UI-automation (System Events / AppleScript) is not permitted here, so I could not click
+  the `.window`-style `MenuBarExtra` item to open the popover, expand the dropdown, toggle Live, or
+  close the popover. Temporary `NSLog("QNS_DEBUG …")` markers were added to `onDisappear`,
+  `.task`/fetch, `startLive`, and `stopLive`, and a unified-log stream was captured while attempting
+  scripted clicks; the clicks never registered (permission-blocked) so no markers were emitted. The
+  debug logging has been removed and the project rebuilt clean.
+  - **What IS verified:** clean Debug + test build; 167/167 unit tests green, covering the logic
+    behind every UI action — fetch assembly (all 4 groups, public-IPv6 success/failure), live-poll
+    start/stop/first-tick-RF/second-tick-throughput, `bytesPerSecond` math, and `refresh()` gating.
+    Readers were exercised on real hardware (Task 3 eyeball). `onDisappear { manager.stopLive() }`
+    is wired as specified.
+  - **What remains for a human/local check:** confirm `onDisappear` actually fires when the
+    `.window` MenuBarExtra popover closes (design's open question). If it turns out not to fire on
+    this macOS, the documented fallback is to observe `NSWindow.willCloseNotification`. Also
+    visually confirm dropdown rendering, live values ticking, and collapsed-on-reopen behavior.
+
+### Task 11 — Final verification & consolidated deviations
+
+- `swiftlint lint` → **0 violations, 0 serious** across 35 files. Two warnings surfaced during
+  implementation and were fixed (not suppressed): the 3-member `previousSample` tuple (`large_tuple`)
+  became a private `ByteSample` struct, and `WifiReader.securityText`'s 16-case switch
+  (`cyclomatic_complexity` 17) became a `[Int: String]` dictionary lookup.
+- Full suite: **167/167 pass** (baseline 110 → +57 new). New test files: `ConnectionDetailsTests`
+  (22), `LiveConnectionStatsTests` (13), `ConnectionReadersTests` (SystemConfig 2, Interface 3,
+  Wifi 2), `ConnectionDetailsManagerTests` (fetch 9 + live 6).
+
+**Design coverage:** every model field, reader, manager API, view, group/row (Interface, Addressing,
+DNS & DHCP, Wi-Fi), the Live section, and all three wiring points are implemented as specified.
+
+**Deviations from the plan (all intentional, all keep the design's intent):**
+
+1. **DHCP lease API** — used `DHCPInfoGetLeaseExpirationTime` directly (the plan's preferred path);
+   the option-51 fallback was unnecessary. Required the explicit
+   `import SystemConfiguration.SCDynamicStoreCopyDHCPInfo` submodule import.
+2. **CoreWLAN enum mapping** — mapped `CWChannelBand`/`CWChannelWidth`/`CWPHYMode`/`CWSecurity` by
+   ABI-stable `rawValue` integers with a `default`/absent → nil, instead of Swift enum-case switches
+   with `@unknown default`. Same guarantee (unknown/future → row omitted, no crash) without the
+   fragile Swift acronym-case casing (`.WEP`/`.OWE`).
+3. **Lint-driven refactors** — `securityText` is a dictionary (not a switch); `previousSample` is a
+   `ByteSample` struct (not the literal `(rx:tx:at:)` tuple). Behavior identical.
+4. **WifiReader smoke test** — iterates `["en0","en1"]` rather than assuming `en0` (this machine's
+   Wi-Fi is `en1`); the fragile `#filePath` source-grep guard for `ssid(`/`bssid(` was dropped per
+   the plan's own escape hatch — the guarantee is upheld by never writing those calls (verifiable by
+   review) and is documented in `WifiReader.swift`.
+5. **Task 10 Step 4 manual run** — could not be performed interactively (headless env blocks UI
+   automation); see the Task 10 note above for exactly what was and was not verified.
+
+### Code-review fixes (2026-07-04, post-review)
+
+- **Important — `InterfaceReader.byteCounters`**: the sysctl `NET_RT_IFLIST2` walk now bounds-checks
+  every `loadUnaligned` (`offset + size(if_msghdr) <= length` loop condition; `if_msghdr2` load
+  additionally guarded by buffer bound and `ifm_msglen`). The MAC read in `readLinkLayer` guards
+  `sdl_data + sdl_nlen + 6 <= sdl_len`. Defense-in-depth against truncated/inconsistent
+  kernel-sourced records — previously a potential buffer over-read.
+- **Important — `firstTickHasRFOnly` test**: poll interval raised 0.3 s → 60 s so the second tick
+  can never race the assertion under CI load; `stopLive()` cancels the sleep so the test stays fast.
+- **Minor (recommended) — `ConnectionDetailsManager.fetchDetails`**: publishes nothing when the
+  task was cancelled (popover closed mid-expand), so the next expand retries instead of keeping a
+  half-fetched snapshot with a silently missing public-IPv6 row.
+- Remaining review findings left intentionally: `@ObservedObject` → `let` in the two pass-through
+  views (energy micro-optimization), `.help` full-value tooltip vs "Click to copy" (plan-internal
+  conflict — current code shows "Click to copy"), no `deinit`-cancels test (impractical under
+  main-actor isolation; leak impossible by construction), duplicated 3-line pasteboard idiom.
+- Human verification 2026-07-04: **`onDisappear` confirmed to fire** when the `.window`
+  MenuBarExtra popover closes — the Live loop stops on close as designed; the
+  `NSWindow.willCloseNotification` fallback is not needed. Federico also applied some UI
+  adjustments by hand before the initial commit.

--- a/context/planning/add-ssid-bssid-location-optin.md
+++ b/context/planning/add-ssid-bssid-location-optin.md
@@ -1,0 +1,626 @@
+# Plan: Opt-in SSID & BSSID via Location Services
+
+> **Date**: 2026-07-07
+> **Scope**: Show the Wi-Fi network name (SSID) below the big Wi-Fi icon in the main window and the
+> BSSID inside Connection Details → Interface, unlocked by an opt-in Location Services permission
+> flow driven from a new toggle in Settings → Connection Details.
+> **Prerequisite**: `feat/detailed-info-dropdown` branch (Connection Details dropdown, Beta 4).
+
+---
+
+## Context
+
+CoreWLAN's `CWInterface.ssid()` / `bssid()` return `nil` on modern macOS unless the app is
+authorized for Location Services — Apple treats network identifiers as location-revealing data.
+The project has deliberately never called them (`WifiReader` doc comment enforces this). To unlock
+them the app needs the sandbox location entitlement, a usage description, and a granted
+`CLLocationManager.requestWhenInUseAuthorization()`.
+
+The user-approved design:
+
+- Opt-in **toggle** in the existing **Settings → Connection Details** page, **default off**.
+- First toggle-on triggers the system location prompt (with a brief usage string explaining that
+  macOS requires location for SSID/BSSID and that location is never collected or stored).
+- If the user **refuses**, the toggle stays off. If they **grant**, it turns on; later off→on
+  toggles never re-prompt (the OS remembers the grant; we read the current status directly).
+- When authorized **and** the toggle is on:
+  - **SSID** appears below the big Wi-Fi icon in the main popover window.
+  - **BSSID** appears as a row in the **Interface** group of Connection Details.
+
+---
+
+## Overview
+
+```
+Settings → Connection Details page
+  └── ToggleView "Show network name (SSID) & BSSID"     [Settings.showNetworkNames]
+        └── custom Binding ──► LocationPermissionManager (NEW, only CoreLocation import)
+                                  .state: notDetermined | authorized | denied
+                                  .requestAuthorization(onGrant:)
+
+Popover window
+  NetStatsView ── ssid ◄── NetworkDetailsManager.ssid ◄── WifiReading.currentSSID()
+  ConnectionDetailsView ── interfaceRows(includeBSSID: settings.showNetworkNames)
+        ▲
+  ConnectionDetailsManager.details.interface.bssid ◄── WifiSnapshot.bssid ◄── CWInterface.bssid()
+```
+
+Data flow stays on the established seams: `WifiReader` remains the ONLY file importing CoreWLAN
+and gains the two location-gated reads; a new `LocationPermissionManager` becomes the ONLY file
+importing CoreLocation. Display gating is `settings.showNetworkNames` (the reads themselves are
+harmless when unauthorized — they just return `nil`, and CoreWLAN never triggers a prompt on its
+own; only `CLLocationManager.requestWhenInUseAuthorization()` does).
+
+---
+
+## Design
+
+### 1. Build settings (project.pbxproj — app target, Debug + Release blocks)
+
+The only pbxproj edits allowed are these build-setting lines (never touch file lists — the project
+uses filesystem-synchronized groups):
+
+- `ENABLE_RESOURCE_ACCESS_LOCATION = NO;` → `YES;` (two occurrences, the app target's Debug and
+  Release configs — currently lines 389 and 440). This injects the
+  `com.apple.security.personal-information.location` sandbox entitlement.
+- Insert in both blocks, alphabetically among the existing `INFOPLIST_KEY_` entries (after
+  `INFOPLIST_KEY_LSUIElement = YES;`):
+
+```
+INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "QuickNetStats never collects or stores your location. macOS requires Location Services permission to read the Wi-Fi network name (SSID) and access point address (BSSID).";
+```
+
+### 2. `LocationPermissionManager` (new — `QuickNetStats/Managers/LocationPermissionManager.swift`)
+
+The ONLY file importing CoreLocation. Never requests a location fix — authorization alone unlocks
+CoreWLAN.
+
+```swift
+import Foundation
+import CoreLocation
+
+/// The app-level view of Location Services authorization, collapsed to the three
+/// states the opt-in toggle cares about.
+enum LocationAuthorizationState {
+    case notDetermined
+    case authorized
+    case denied
+}
+
+/// Owns the `CLLocationManager` used solely to unlock CoreWLAN's location-gated
+/// SSID/BSSID reads. Never requests a location fix. This is the ONLY file that
+/// imports CoreLocation.
+class LocationPermissionManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+
+    /// The current authorization state; updates whenever the system reports a change.
+    @Published private(set) var state: LocationAuthorizationState
+
+    private let manager: CLLocationManager
+
+    /// Pending grant continuation from `requestAuthorization(onGrant:)`; fired once
+    /// the user answers the system prompt with a grant, discarded on refusal.
+    private var onGrant: (() -> Void)?
+
+    override init() {
+        let manager = CLLocationManager()
+        self.manager = manager
+        self.state = Self.state(from: manager.authorizationStatus)
+        super.init()
+        manager.delegate = self
+    }
+
+    /// Shows the system location prompt (only possible while `.notDetermined`) and
+    /// runs `onGrant` if the user authorizes.
+    func requestAuthorization(onGrant: @escaping () -> Void) {
+        self.onGrant = onGrant
+        manager.requestWhenInUseAuthorization()
+    }
+
+    /// Delegate callbacks are not actor-isolated; hop to the main actor before
+    /// touching published state.
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
+        Task { @MainActor in
+            self.apply(status)
+        }
+    }
+
+    /// Publishes the new state and settles the pending grant continuation.
+    private func apply(_ status: CLAuthorizationStatus) {
+        state = Self.state(from: status)
+        switch state {
+        case .authorized:
+            onGrant?()
+            onGrant = nil
+        case .denied:
+            onGrant = nil
+        case .notDetermined:
+            break
+        }
+    }
+
+    /// Collapses `CLAuthorizationStatus` to the app's three-state view. Unknown
+    /// future cases degrade to `.denied` (no prompt, nothing displayed).
+    nonisolated static func state(from status: CLAuthorizationStatus) -> LocationAuthorizationState {
+        switch status {
+        case .notDetermined: return .notDetermined
+        case .authorizedAlways, .authorizedWhenInUse: return .authorized
+        case .denied, .restricted: return .denied
+        @unknown default: return .denied
+        }
+    }
+}
+```
+
+**Compiler gotchas** (the project builds with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`):
+- Do NOT list `.authorized` alongside `.authorizedAlways` — on macOS it is a deprecated alias with
+  the same raw value and produces a duplicate-case error.
+- The delegate method and the static mapper must be `nonisolated` as shown.
+
+### 3. `Settings.showNetworkNames`
+
+`QuickNetStats/Models/Settings.swift` — new key + property following the existing pattern:
+
+```swift
+static let showNetworkNames = "showNetworkNames"
+```
+
+```swift
+/// Opt-in display of the Wi-Fi SSID (main window) and BSSID (Connection Details).
+/// Turning it on for the first time triggers the Location Services prompt macOS
+/// requires for these reads; see `LocationPermissionManager`.
+@AppStorage(UserDefaultsKeys.showNetworkNames)
+var showNetworkNames: Bool = false
+```
+
+### 4. `WifiReader` — the lifted constraint
+
+The standing "never call `ssid()`/`bssid()`" rule is **deliberately lifted**, in this file only.
+
+- `WifiSnapshot` gains `var bssid: String?`.
+- `snapshot(for:)` adds `snapshot.bssid = interface.bssid()` (nil when unauthorized — graceful).
+- `WifiReading` protocol gains the main-window read:
+
+```swift
+protocol WifiReading {
+    func snapshot(for bsdName: String) -> WifiSnapshot?
+    /// The SSID of the default Wi-Fi interface; nil off Wi-Fi or when Location
+    /// Services authorization is missing.
+    func currentSSID() -> String?
+}
+```
+
+```swift
+func currentSSID() -> String? {
+    CWWiFiClient.shared().interface()?.ssid()
+}
+```
+
+- Update the type doc comment: replace the "**`ssid()`/`bssid()` are location-gated and never
+  called.**" sentence with one explaining they are now read and return nil without Location
+  Services authorization (see `LocationPermissionManager`).
+
+### 5. `NetworkDetailsManager` — SSID for the main window
+
+The popover already fetches the IPs through this manager on open and refresh; the SSID rides along:
+
+- `@Published var ssid: String?`
+- `init(session: URLSession = .reachabilitySession, wifiReader: WifiReading = WifiReader())`
+- `getAddresses()` adds `self.ssid = wifiReader.currentSSID()`
+- `deleteAndGetAddresses()` also nils it first, then re-reads.
+
+### 6. `ConnectionDetails` — BSSID row under Interface
+
+- `Interface` gains `var bssid: String?`.
+- `interfaceRows(rateUnit:includeBSSID:)` — the new parameter defaults to `false` so every existing
+  call site, preview, and test stays byte-identical:
+
+```swift
+func interfaceRows(rateUnit: RateUnit = .bitsPerSecond, includeBSSID: Bool = false) -> [DetailRow] {
+```
+
+  The row goes right after "MAC address" (both are L2 identifiers):
+
+```swift
+if includeBSSID, let bssid = interface.bssid {
+    rows.append(DetailRow(label: "BSSID", value: bssid))
+}
+```
+
+- `mockWifi` gains `bssid: "aa:bb:cc:11:22:33"` in its `Interface` init.
+
+### 7. `ConnectionDetailsManager` — pass-through
+
+In `fetchDetails()`, the `interface:` group init gains `bssid: wifiSnapshot?.bssid`. Note
+`wifiSnapshot` is read before the row is built, exactly as today; no ordering change.
+
+### 8. Settings UI — the opt-in toggle (`ConnectionDetailsSettingsView`)
+
+New `@StateObject private var locationPermission = LocationPermissionManager()` and a new Form
+section after "Live Stats":
+
+```swift
+Section {
+    ToggleView(
+        title: "Show network name (SSID) & BSSID",
+        variable: showNetworkNamesBinding,
+        description: "Displays the Wi-Fi name in the main window and the BSSID in "
+            + "'Connection Details'. macOS requires Location Services permission for "
+            + "these; your location is never collected or stored."
+    )
+
+    if locationPermission.state == .denied {
+        HStack {
+            Text("Location access is denied. Allow QuickNetStats under Privacy & Security → Location Services.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+            Button("Open Settings") { openLocationSettings() }
+        }
+    }
+} header: {
+    Text("Network Names")
+}
+```
+
+The custom binding implements the approved first-time-prompt flow — the toggle only lands on `true`
+once authorization actually exists:
+
+```swift
+/// Bridges the toggle to `Settings.showNetworkNames`, injecting the one-time
+/// Location Services prompt: while undetermined the toggle stays off and the
+/// system prompt decides; once authorized it flips freely without re-prompting.
+private var showNetworkNamesBinding: Binding<Bool> {
+    Binding(
+        get: { settings.showNetworkNames },
+        set: { isOn in
+            guard isOn else {
+                settings.showNetworkNames = false
+                return
+            }
+            switch locationPermission.state {
+            case .authorized:
+                settings.showNetworkNames = true
+            case .notDetermined:
+                locationPermission.requestAuthorization {
+                    settings.showNetworkNames = true
+                }
+            case .denied:
+                break   // stays off; the caption below offers the recovery path
+            }
+        }
+    )
+}
+```
+
+```swift
+/// Opens System Settings on the Location Services privacy pane (mirrors
+/// `ContentView.openNetworkSettings()`).
+private func openLocationSettings() {
+    let urlString = "x-apple.systempreferences:com.apple.preference.security?Privacy_LocationServices"
+    if let url = URL(string: urlString) {
+        NSWorkspace.shared.open(url)
+    }
+}
+```
+
+(`import AppKit` if not already pulled in via SwiftUI.)
+
+### 9. Popover UI
+
+**`NetStatsView`** — `init` gains `ssid: String? = nil` (defaulted so previews keep compiling),
+stored on the view model alongside the IPs (`NetStatsViewModel` gains `var ssid: String?` and a
+matching defaulted init parameter: `init(netStats:privateIP:publicIP:ssid: String? = nil)`, so
+existing view-model tests compile unchanged). The big icon is wrapped so the SSID sits directly below it:
+
+```swift
+VStack(spacing: 6) {
+    NetworkInterfaceView(
+        netInterfaceType: vm.netStats.interfaceType,
+        isAvailable: vm.netStats.isConnected,
+        linkQualityColor: settings.isColorful ? vm.linkQualityColor : monochromeColor
+    )
+    .frame(height: 80)
+
+    if settings.showNetworkNames, vm.isWifiConnection, let ssid = vm.ssid {
+        Text(ssid)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+    }
+}
+```
+
+`NetStatsViewModel` gains the gate (covers real Wi-Fi and hotspot-over-Wi-Fi, and keeps a stale
+SSID from showing under the Ethernet icon):
+
+```swift
+/// True when the SSID label is meaningful: the active connection actually rides Wi-Fi.
+var isWifiConnection: Bool {
+    netStats.interfaceType == .wifi || netStats.connectionTechnology == .wifi
+}
+```
+
+**`ContentView`** passes `ssid: netDetailsManager.ssid` into `NetStatsView`.
+
+**`ConnectionDetailsView`** line 25 becomes:
+
+```swift
+DetailGroupView(title: "Interface", rows: details.interfaceRows(rateUnit: settings.interfaceRateUnit, includeBSSID: settings.showNetworkNames))
+```
+
+Update the "Good Connection" preview in `NetStatsView` to pass `ssid: "HomeNet 5GHz"` (others keep
+the nil default).
+
+---
+
+## Edge Cases & Constraints
+
+- **Refusal is sticky at the OS level.** After a denial, `requestWhenInUseAuthorization()` never
+  re-prompts. The toggle therefore snaps back off and the denied caption + "Open Settings" button
+  are the only recovery path. This matches the approved design ("if the user refuses, the toggle
+  stays off").
+- **Authorization revoked later in System Settings** while the toggle is on: `ssid()`/`bssid()`
+  return nil, so the SSID label and BSSID row silently disappear (existing nil-omission
+  convention). The toggle itself stays on; the denied caption appears next time the settings page
+  is opened.
+- **LSUIElement intermittent nil**: agent apps on macOS 14.4+ are known to intermittently get nil
+  SSID/BSSID even when properly authorized (Apple forums 748518 / 816619, unfixable by
+  configuration). Nil-omission degrades gracefully; never show an error state for it.
+- **Stale BSSID**: Connection Details are cached after first expand; a grant given while the
+  popover data already exists shows up after the refresh button (which calls
+  `connectionDetailsManager.refresh()`) or the next fetch. Accepted; no extra invalidation logic.
+- **Prompt requires a properly signed app run outside Xcode** (Apple DTS): the system prompt and
+  the unlock only behave correctly from an exported/archived signed build. Unit tests cover the
+  pure logic; end-to-end verification is manual from a Release export.
+- **Grant while off the settings page**: the page-local `LocationPermissionManager` (a
+  `@StateObject`) deallocates if the user leaves the page mid-prompt, dropping the `onGrant`
+  continuation. On return the state reads `.authorized`, so flipping the toggle again succeeds
+  instantly without a prompt. Accepted.
+- **No new rows beyond the spec**: SSID appears only under the main icon, BSSID only under
+  Interface. The Wi-Fi group of Connection Details is unchanged.
+- **CoreLocation confined to `LocationPermissionManager`; CoreWLAN confined to `WifiReader`.**
+
+---
+
+## Implementation Checklist
+
+> **For agentic workers:** Execute task-by-task with TDD. Test command (plain `xcodebuild`
+> resolves to CommandLineTools and fails; the Mac sleeps mid-run without `caffeinate`):
+>
+> ```bash
+> caffeinate -dims env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
+>   xcodebuild test -project QuickNetStats.xcodeproj -scheme QuickNetStats -destination 'platform=macOS'
+> ```
+>
+> Append `-only-testing:QuickNetStatsTests/<SuiteStructName>` for a focused run. Lint with
+> `env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer swiftlint lint`.
+> **Never run `git commit`/`git add`/`git push`.** New source files auto-join the target
+> (filesystem-synchronized groups) — never edit `project.pbxproj` file lists; the ONLY pbxproj
+> edits permitted are the build-setting lines in Task 6. Do not `#if DEBUG`-guard preview helpers
+> (#Preview bodies compile in Release).
+
+### Task 1: `Settings.showNetworkNames`
+
+- [x] Add a failing test to `QuickNetStatsTests/SettingsTests.swift` inside `SettingsDefaultsTests`, copying the existing UserDefaults-isolated pattern (e.g. `startLiveMonitoringOnOpenDefaultsToFalse`): remove key `Settings.UserDefaultsKeys.showNetworkNames`, defer restore, `#expect(Settings().showNetworkNames == false)`. Run: fails to compile (key missing) — that is the red step.
+- [x] Implement: add the `showNetworkNames` key and `@AppStorage` property (Design §3) to `QuickNetStats/Models/Settings.swift`.
+- [x] Run the `Settings Defaults` suite — green.
+
+### Task 2: `LocationPermissionManager`
+
+- [x] Create `QuickNetStatsTests/LocationPermissionManagerTests.swift` with a parameterized Swift Testing suite over the mapping (import `CoreLocation` and `Testing`):
+
+```swift
+@Test(
+    "CLAuthorizationStatus maps to the app's three states",
+    arguments: [
+        (CLAuthorizationStatus.notDetermined, LocationAuthorizationState.notDetermined),
+        (CLAuthorizationStatus.authorizedAlways, LocationAuthorizationState.authorized),
+        (CLAuthorizationStatus.denied, LocationAuthorizationState.denied),
+        (CLAuthorizationStatus.restricted, LocationAuthorizationState.denied),
+    ]
+)
+func statusMapping(status: CLAuthorizationStatus, expected: LocationAuthorizationState) {
+    #expect(LocationPermissionManager.state(from: status) == expected)
+}
+```
+
+- [x] Run — fails to compile (type missing).
+- [x] Create `QuickNetStats/Managers/LocationPermissionManager.swift` exactly as in Design §2 (mind the two compiler gotchas).
+- [x] Run the new suite — green. (`LocationAuthorizationState` needs no explicit `Equatable`; enums without associated values get it for free, but the test needs it usable — add `: Equatable` if `#expect` complains.)
+
+### Task 3: `WifiReader` — bssid in snapshot + `currentSSID()`
+
+- [x] Add `var bssid: String?` to `WifiSnapshot`, add `currentSSID()` to the `WifiReading` protocol and `WifiReader` (Design §4), update the type doc comment, and update `MockWifiReader` in `QuickNetStatsTests/ConnectionDetailsManagerTests.swift` to conform:
+
+```swift
+final class MockWifiReader: WifiReading {
+    var result: WifiSnapshot?
+    var currentSSIDResult: String?
+    private(set) var callCount = 0
+    init(result: WifiSnapshot?, currentSSID: String? = nil) {
+        self.result = result
+        self.currentSSIDResult = currentSSID
+    }
+    func snapshot(for bsdName: String) -> WifiSnapshot? {
+        callCount += 1
+        return result
+    }
+    func currentSSID() -> String? { currentSSIDResult }
+}
+```
+
+  (No unit test can exercise the real CoreWLAN reads; the seam is the test surface — Tasks 4–5 cover it.)
+- [x] Full test run — green (this task must not change any behavior).
+
+### Task 4: `ConnectionDetails` — BSSID row
+
+- [x] Add failing tests to `QuickNetStatsTests/ConnectionDetailsTests.swift` (match the file's existing style):
+
+```swift
+@Test("interfaceRows includes BSSID after MAC address when opted in")
+func interfaceRowsIncludeBSSIDWhenOptedIn() {
+    let rows = ConnectionDetails.mockWifi.interfaceRows(includeBSSID: true)
+    let labels = rows.map(\.label)
+    #expect(rows.contains(DetailRow(label: "BSSID", value: "aa:bb:cc:11:22:33")))
+    #expect(labels.firstIndex(of: "BSSID") == labels.firstIndex(of: "MAC address").map { $0 + 1 })
+}
+
+@Test("interfaceRows omits BSSID by default")
+func interfaceRowsOmitBSSIDByDefault() {
+    let labels = ConnectionDetails.mockWifi.interfaceRows().map(\.label)
+    #expect(!labels.contains("BSSID"))
+}
+
+@Test("interfaceRows omits BSSID when the value is missing")
+func interfaceRowsOmitNilBSSID() {
+    var details = ConnectionDetails.mockWifi
+    details.interface.bssid = nil
+    let labels = details.interfaceRows(includeBSSID: true).map(\.label)
+    #expect(!labels.contains("BSSID"))
+}
+```
+
+- [x] Run — red.
+- [x] Implement Design §6: `Interface.bssid`, the `includeBSSID` parameter and row, `mockWifi` gains `bssid: "aa:bb:cc:11:22:33"`.
+- [x] Run the `ConnectionDetails` suite — green.
+
+### Task 5: `ConnectionDetailsManager` pass-through
+
+- [x] Add a failing test to `QuickNetStatsTests/ConnectionDetailsManagerTests.swift`: give the `fullWifi` fixture `bssid: "de:ad:be:ef:00:01"` (add the field to the fixture init), fetch with the standard mocks (copy the `fetchAssemblesGroups` arrangement), `#expect(manager.details?.interface.bssid == "de:ad:be:ef:00:01")`.
+- [x] Run — red.
+- [x] Implement Design §7: pass `bssid: wifiSnapshot?.bssid` in `fetchDetails()`.
+- [x] Run the `ConnectionDetailsManager` suite — green.
+
+### Task 6: `NetworkDetailsManager.ssid` + build settings
+
+- [x] Add a failing test to `QuickNetStatsTests/NetworkDetailsManagerTests.swift` (reuse `MockWifiReader` — same module):
+
+```swift
+@Test("getAddresses populates the SSID from the Wi-Fi reader")
+func ssidFetched() async {
+    MockURLProtocol.requestHandler = { request in
+        let response = HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil)!
+        return (response, Data())
+    }
+
+    let manager = NetworkDetailsManager(
+        session: mockSession(),
+        wifiReader: MockWifiReader(result: nil, currentSSID: "HomeNet")
+    )
+    await manager.getAddresses()
+
+    #expect(manager.ssid == "HomeNet")
+}
+```
+
+- [x] Run — red.
+- [x] Implement Design §5 in `QuickNetStats/Managers/NetworkDetailsManager.swift`.
+- [x] Run the `NetworkDetailsManager` suite — green.
+- [x] Apply the pbxproj build-setting edits from Design §1 (both app-target blocks: `ENABLE_RESOURCE_ACCESS_LOCATION = YES;` and the `INFOPLIST_KEY_NSLocationWhenInUseUsageDescription` line). These are the ONLY pbxproj lines touched.
+- [x] Full build succeeds (`xcodebuild ... build` variant of the command above).
+
+### Task 7: Settings UI toggle
+
+- [x] Implement Design §8 in `QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift` (StateObject, "Network Names" section, custom binding, denied caption, `openLocationSettings()`). No unit test — SwiftUI + TCC; verified by build, previews, and the manual pass below.
+- [x] Full build succeeds; existing previews still compile.
+
+### Task 8: Popover UI
+
+- [ ] Add a failing test for the gate to `QuickNetStatsTests/NetStatsViewModelTests.swift` (match the file's existing style; note the wired-hotspot mock is `false` because its technology is `.wiredEthernet`):
+
+```swift
+@Test(
+    "isWifiConnection is true only when the connection rides Wi-Fi",
+    arguments: [
+        (NetworkStats.mockGoodWifiConnection, true),
+        (NetworkStats.mockGoodEthConnection, false),
+        (NetworkStats.mockConstrainedExpensiveCellConnection, true),   // hotspot over Wi-Fi
+        (NetworkStats.mockExpensiveCellConnection, false),             // hotspot over cable
+        (NetworkStats.mockDisconnected, false),
+    ]
+)
+func isWifiConnectionGate(netStats: NetworkStats, expected: Bool) {
+    let vm = NetStatsViewModel(netStats: netStats, privateIP: nil, publicIP: nil)
+    #expect(vm.isWifiConnection == expected)
+}
+```
+
+- [x] Run — red (`isWifiConnection` missing).
+- [x] Implement Design §9: `NetStatsViewModel` (`ssid` + `isWifiConnection`), `NetStatsView` (init param, VStack under the icon, "Good Connection" preview gains `ssid: "HomeNet 5GHz"`), `ContentView` passes `netDetailsManager.ssid`, `ConnectionDetailsView` passes `includeBSSID: settings.showNetworkNames`.
+- [x] Run the `NetStatsViewModel` suite — green.
+
+### Task 9: Full verification
+
+- [x] Full test suite — `** TEST SUCCEEDED **` (trust the marker, not the interleaved case counts).
+- [x] `swiftlint lint` — 0 violations.
+- [x] Check every box above; append honest Implementation Notes (deviations, observations) to this file.
+
+### Manual verification (Federico, from an exported signed build)
+
+- [ ] Toggle on in Settings → Connection Details → system prompt appears with the usage string.
+- [ ] Refuse → toggle stays off; denied caption + "Open Settings" appear; re-toggling does not re-prompt (macOS behavior) — recovery only via System Settings.
+- [ ] Grant → toggle turns on; SSID shows under the Wi-Fi icon; BSSID row shows under Interface after a refresh/expand.
+- [ ] Toggle off → both disappear immediately; toggle back on → no prompt, values return.
+- [ ] On Ethernet-primary with Wi-Fi also connected: no SSID under the Ethernet icon.
+
+---
+
+## Implementation Notes
+
+> **Date executed**: 2026-07-07 — TDD, task-by-task, all 9 tasks green.
+
+### Deviations from the plan's exact code (all minimal, compiler-driven)
+
+- **`LocationPermissionManager.swift` needs `import Combine`.** Design §2 lists only
+  `Foundation` + `CoreLocation`, but `@Published` / `ObservableObject` conformance fails to
+  compile without `Combine` (`initializer 'init(wrappedValue:)' is not available due to missing
+  import of defining module 'Combine'`). Added `import Combine` — matches the other managers
+  (`NetworkDetailsManager`, `ConnectionDetailsManager`) which already import it. The two documented
+  compiler gotchas (no `.authorized` alias next to `.authorizedAlways`; `nonisolated` delegate +
+  `Task { @MainActor }` hop) were correct as written and needed no change.
+
+- **`NetStatsViewModel.swift` needs `import Network`.** Design §9's `isWifiConnection` compares
+  `netStats.connectionTechnology == .wifi`, and `connectionTechnology` is
+  `NWInterface.InterfaceType`, so referring to the `.wifi` case requires `Network` imported (the
+  file previously imported only `SwiftUI`; `NetStatsView.swift` already imports `Network`). Added
+  `import Network`.
+
+- **`ConnectionDetailsView.swift` line 25 wrapped for line length.** Adding
+  `includeBSSID: settings.showNetworkNames` pushed the single-line `DetailGroupView(title:
+  "Interface", …)` call to 163 chars (SwiftLint `line_length` warns at 160). Split the call across
+  multiple lines; semantically identical, and `swiftlint lint` then reported 0 violations.
+
+### Observations
+
+- **Pre-existing-style async warning on the new parameterized test.** `isWifiConnectionGate`'s
+  `arguments:` array references the `NetworkStats.mock*` statics, which are `MainActor`-isolated
+  under the project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` setting, so the macro expansion
+  emits `expression is 'async' but is not marked with 'await'; this is an error in the Swift 6
+  language mode`. This is the same shape as the pre-existing `linkQualityColorMapping` test in the
+  same file; harmless under the project's Swift 5 mode (`-swift-version 5`), it is a warning not an
+  error, the test executes and all 5 cases pass. Left as-is to match the plan's provided test code
+  and the surrounding file style.
+
+- **pbxproj edits were confined to the four allowed build-setting lines.** In both the app target's
+  Debug and Release blocks: `ENABLE_RESOURCE_ACCESS_LOCATION = NO;` → `YES;` and a new
+  `INFOPLIST_KEY_NSLocationWhenInUseUsageDescription` line inserted alphabetically after
+  `INFOPLIST_KEY_NSHumanReadableCopyright`. No file-list entries were touched; the two new `.swift`
+  files auto-joined the target via the filesystem-synchronized group.
+
+- **Framework confinement preserved.** CoreWLAN remains imported only in `WifiReader.swift`
+  (SSID/BSSID reads added there); CoreLocation only in `LocationPermissionManager.swift`.
+
+- **Final verification:** full `xcodebuild test` → `** TEST SUCCEEDED **`; `swiftlint lint` →
+  `Found 0 violations`. The end-to-end Location Services prompt cannot be exercised from unit tests
+  (requires a signed build run outside Xcode per Apple DTS) — the Manual verification checklist
+  above is left for Federico.
+
+- **Post-implementation fix (user-tested, 2026-07-07): restart required after first grant.**
+  Manual testing showed CoreWLAN does not pick up a freshly granted Location Services permission
+  in the running process — `ssid()`/`bssid()` stay nil until the app relaunches. Added a
+  "Restart QuickNetStats" alert in `ConnectionDetailsSettingsView`, shown only from the
+  first-grant path (`requestAuthorization` completion), with "Quit Now" (`NSApp.terminate`) and
+  "Later" buttons. Later off→on toggles never show it (permission already applied at launch).

--- a/context/planning/customizable-connection-details-units.md
+++ b/context/planning/customizable-connection-details-units.md
@@ -1,0 +1,317 @@
+# Plan: Customizable Units for Connection Details
+
+> **Date**: 2026-07-06
+> **Scope**: A new Settings page letting the user choose, per rate-bearing Connection Details
+> section, whether rates display in bits-per-second (bps/Kbps/Mbps/Gbps) or bytes-per-second
+> (B/s/KB/s/MB/s/GB/s), backed by one shared bits↔bytes conversion/formatting utility.
+> **Prerequisite**: The Connection Details dropdown and its coverage expansion
+> (`add-connection-details-dropdown.md`, `expand-connection-details-coverage.md`).
+
+---
+
+## Context
+
+All rate values in the dropdown are currently formatted in their native unit family: Link speed
+and Tx rate in bits (Mbps/Gbps, via `ConnectionDetails.Interface.linkSpeedText` and
+`LiveConnectionStats.txRateText`), Download/Upload throughput in bytes (`LiveConnectionStats.rateText`).
+Users think in different units (ISPs sell Mbps; downloads read in MB/s), so each section gets a
+user preference. Canonical example: Link speed natively 210 Mbps → switchable to "26.25 MB/s".
+
+Three sections carry bit/byte rates:
+
+| Settings section | Rows governed | Native unit |
+|---|---|---|
+| Interface | Link speed | bits |
+| Wi-Fi | Tx rate (rendered in the Live grid, but it is Wi-Fi RF data) | bits |
+| Live | Download, Upload | bytes |
+
+Defaults equal the native unit, so the default UI is pixel-identical to today. Packets/Errors/
+Drops are counts, not data rates — unaffected. Tx power (mW) unaffected.
+
+---
+
+## Overview
+
+```
+Settings (@AppStorage, 3 new prefs)          DataRate.swift (NEW, shared utility)
+ ├─ interfaceRateUnit : RateUnit = .bits      ├─ enum RateUnit: String { bits, bytes }
+ ├─ wifiRateUnit      : RateUnit = .bits      ├─ bitsToBytes / bytesToBits   (÷8 / ×8)
+ └─ liveRateUnit      : RateUnit = .bytes     └─ text(bitsPerSecond:in:) / text(bytesPerSecond:in:)
+                                                  auto-scaled multiples, ≤2 decimals, zeros stripped
+SettingsView
+ └─ new page "Connection Details" (SettingsViewModel.SettingsPage.connectionDetails)
+     └─ ConnectionDetailsSettingsView: three labeled unit pickers (Interface / Wi-Fi / Live)
+
+ConnectionDetailsView (dropdown)
+ ├─ details.interfaceRows(rateUnit: settings.interfaceRateUnit)
+ └─ LiveStatsSectionView(..., liveUnit: settings.liveRateUnit, wifiRateUnit: settings.wifiRateUnit)
+```
+
+---
+
+## Design
+
+### Shared utility (`QuickNetStats/Models/DataRate.swift`, NEW)
+
+```swift
+/// The unit family used to display a data rate.
+enum RateUnit: String, CaseIterable, Identifiable {
+    case bitsPerSecond = "bps"
+    case bytesPerSecond = "B/s"
+    var id: String { rawValue }
+    var displayName: String   // "Bits per second (Mbps)" / "Bytes per second (MB/s)"
+}
+
+/// Shared bits <-> bytes conversion and auto-scaling rate formatting.
+enum DataRate {
+    static func bitsToBytes(_ bitsPerSecond: Double) -> Double    // ÷ 8
+    static func bytesToBits(_ bytesPerSecond: Double) -> Double   // × 8
+    static func text(bitsPerSecond: Double, in unit: RateUnit) -> String
+    static func text(bytesPerSecond: Double, in unit: RateUnit) -> String
+}
+```
+
+Formatting rules (both families, base-1000 multiples):
+- bits: `bps`, `Kbps`, `Mbps`, `Gbps`; bytes: `B/s`, `KB/s`, `MB/s`, `GB/s`.
+- Scale to the largest multiple ≥ 1; up to 2 decimals, trailing zeros stripped
+  ("866 Mbps", "1 Gbps", "2.5 Gbps", "26.25 MB/s", "999 B/s").
+- Conversions: 210 Mbps → "26.25 MB/s"; 866 Mbps → "108.25 MB/s"; 1 GB/s → "8 Gbps".
+
+Existing formatters become thin wrappers over `DataRate` (single source of truth):
+- `ConnectionDetails.Interface` link-speed formatting → `DataRate.text(bitsPerSecond: mbps * 1e6, in: unit)`.
+- `LiveConnectionStats.rateText` (bytes) and `txRateText` (bits) → routed through `DataRate`.
+Their current default-unit outputs must not change (existing tests are the regression net; the
+current "866 Mbps" / "1.2 MB/s"-style strings stay identical for default units).
+
+### Settings model (`QuickNetStats/Models/Settings.swift`)
+
+Three new `@AppStorage` properties (RawRepresentable-String storage, macOS 13-safe), defaults =
+native units, with `UserDefaultsKeys` entries following the existing pattern:
+
+```swift
+@AppStorage(UserDefaultsKeys.interfaceRateUnit) var interfaceRateUnit: RateUnit = .bitsPerSecond
+@AppStorage(UserDefaultsKeys.wifiRateUnit)      var wifiRateUnit: RateUnit = .bitsPerSecond
+@AppStorage(UserDefaultsKeys.liveRateUnit)      var liveRateUnit: RateUnit = .bytesPerSecond
+```
+
+### Model changes (unit threading — views stay dumb, models stay Settings-free)
+
+- `ConnectionDetails.interfaceRows` becomes `interfaceRows(rateUnit: RateUnit = .bitsPerSecond)`;
+  only the "Link speed" row's value changes with the unit. (Default argument keeps previews and
+  existing call sites/tests compiling unchanged.)
+- `LiveConnectionStats`: `downloadText`/`uploadText`/`txRateText` gain parameterized variants
+  `downloadText(in:)`, `uploadText(in:)`, `txRateText(in:)`; the existing computed properties
+  delegate to them with native units.
+- No stored model data changes — native values remain the stored truth; units are display-only.
+
+### Settings UI
+
+- `SettingsViewModel.SettingsPage`: new case `connectionDetails`, inserted after `.visuals`.
+  Title "Connection Details", icon `"gauge.with.dots.needle.67percent"` (fallback if unavailable
+  at target: `"speedometer"`), color `.orange` (distinct from the existing red/blue/green/gray).
+- New view `QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift`, wired into
+  `SettingsView`'s page switch like the existing pages. Content: three pickers (segmented or the
+  project's `PickerView` component — follow whichever pattern `NotificationView` uses), one per
+  section, each with a caption describing which rows it affects:
+  - "Interface — Link speed"
+  - "Wi-Fi — Tx rate"
+  - "Live — Download and Upload"
+- Preview with a `Settings()` environment object, like sibling pages.
+
+### Dropdown wiring
+
+- `ConnectionDetailsView` (has `settings` already): pass `settings.interfaceRateUnit` into
+  `interfaceRows(rateUnit:)`; pass `settings.liveRateUnit` and `settings.wifiRateUnit` into
+  `LiveStatsSectionView` as two new `let` parameters, used for Download/Upload and Tx rate
+  respectively. Because `settings` is an `@EnvironmentObject`, changing a picker re-renders the
+  dropdown automatically — no extra plumbing.
+
+### Testing (Swift Testing, TDD)
+
+- **`DataRateTests` (new file)**: conversion round-trips (÷8/×8), formatting across all multiples
+  in both families, decimal/stripping rules, the canonical 210 Mbps → "26.25 MB/s", boundary
+  values (999 vs 1000), zero.
+- **`ConnectionDetailsTests`**: Link speed row in both units; default-argument path unchanged.
+- **`LiveConnectionStatsTests`**: parameterized text funcs in both units; existing computed
+  properties still native (regression).
+- **`SettingsTests`**: `RateUnit` raw values and id; the three new preference defaults
+  (UserDefaults-isolated like `keepDetailsExpanded`'s test).
+- **`SettingsViewModelTests`**: update `allCases` count 4 → 5 and add the new page's
+  title/icon/color to the parameterized cases (existing tests WILL fail until updated — that is
+  the expected RED step, not collateral damage).
+
+---
+
+## Edge Cases & Constraints
+
+- **Numeric fidelity**: conversion before scaling (single Double division) — no compounding
+  rounding; 2-decimal display rounding only at the end.
+- **`rateText`'s current outputs** (used by Download/Upload today) must be reproduced exactly by
+  the `DataRate` bytes-family path for default units — diff the formatting rules first, port the
+  existing rules rather than inventing new ones, and let the existing tests arbitrate.
+- **Sub-1 bps/B/s values**: clamp to base unit with the same ≤2-decimal rule ("0.13 B/s" is
+  acceptable; no sub-multiples).
+- **AppStorage + enum**: `@AppStorage` requires `RawRepresentable where RawValue == String` —
+  `RateUnit: String` satisfies it; a stale/unknown stored raw value falls back to the default via
+  the property's default argument semantics (verify: AppStorage keeps the default when the stored
+  raw doesn't decode).
+- **macOS 13 floor**: SF Symbol availability for the page icon must be verified at target
+  (fallback listed). No other new API.
+- **Out of scope**: per-row unit overrides, additional unit families (e.g. Kibi/Mebi base-1024),
+  persisting a unit choice into copied clipboard values (rows copy the displayed string, as they
+  already do).
+
+---
+
+## Implementation Plan
+
+> **For agentic workers:** execute task-by-task with strict TDD (failing tests → run → implement
+> → green). Check each box immediately on step completion. Invoke
+> `swift-testing-expert:swift-testing-expert` before test work and
+> `swiftui-expert:swiftui-expert-skill` before view work. Fill "Implementation Notes" with real
+> observations only. **Never `git add`/`commit`/`push`.** Do not edit `project.pbxproj`.
+> Build/test: `caffeinate -dims env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer xcodebuild test -project QuickNetStats.xcodeproj -scheme QuickNetStats -destination 'platform=macOS'`
+> (plain `xcodebuild` fails; the Mac sleeps mid-run without caffeinate). Baseline: 231 test cases
+> green (xcodebuild counts parameterized arguments individually), swiftlint 0. SourceKit editor
+> diagnostics are stale-indexer noise.
+
+### Task 1: `DataRate` shared utility
+
+- [x] **Step 1**: New `QuickNetStatsTests/DataRateTests.swift` with failing tests per Design
+  (conversions, both formatting families across all multiples, 210 Mbps → "26.25 MB/s",
+  stripping/boundary/zero rules). First diff `LiveConnectionStats.rateText`'s existing rules and
+  encode them as the bytes-family expectations.
+- [x] **Step 2**: Run → compile failure. **Step 3**: Implement `QuickNetStats/Models/DataRate.swift`
+  (`RateUnit` + `DataRate`). **Step 4**: Green.
+
+### Task 2: Route existing formatters through `DataRate`
+
+- [x] **Step 1**: Failing tests: `interfaceRows(rateUnit: .bytesPerSecond)` Link-speed row
+  ("210 Mbps" fixture → "26.25 MB/s"); `downloadText(in:)`/`uploadText(in:)`/`txRateText(in:)`
+  both units; existing computed properties unchanged.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement (thin wrappers, default arguments preserve
+  all current call sites). **Step 4**: Full suite green — existing formatting tests are the
+  regression net.
+
+### Task 3: Settings model
+
+- [x] **Step 1**: Failing tests: three new preference defaults (UserDefaults-isolated, pattern of
+  `keepDetailsExpandedDefaultsToFalse`), `RateUnit` raw values/ids.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement `@AppStorage` props + keys. **Step 4**: Green.
+
+### Task 4: Settings page
+
+- [x] **Step 1**: Update `SettingsViewModelTests` FIRST (count 5, new page title/icon/color
+  params) → run → RED. Invoke swiftui-expert.
+- [x] **Step 2**: Add `SettingsPage.connectionDetails` (after `.visuals`) and create
+  `ConnectionDetailsSettingsView` with the three pickers + captions, wired into `SettingsView`'s
+  switch; preview added. Verify the SF Symbol renders at macOS 13 target (fallback per Design).
+- [x] **Step 3**: Full suite green; build succeeds.
+
+### Task 5: Dropdown wiring
+
+- [x] **Step 1**: Invoke swiftui-expert (if context lost). Thread `settings.interfaceRateUnit`
+  into `interfaceRows(rateUnit:)` in `ConnectionDetailsView`; add `liveUnit`/`wifiRateUnit`
+  parameters to `LiveStatsSectionView` and use them for Download/Upload/Tx rate; update its
+  previews and any other call sites.
+- [x] **Step 2**: Build succeeds; full suite green.
+
+### Task 6: Final verification
+
+- [x] **Step 1**: swiftlint → 0 violations.
+- [x] **Step 2**: Full suite green; re-read Design and confirm every behavior implemented or its
+  absence noted below; record deviations.
+
+---
+
+## Implementation Notes (deviations & observations)
+
+### Formatting-rule reconciliation (Tasks 1–2)
+
+- **Bytes-family conflict (ported the OLD rule).** The new `DataRate` bytes formatter uses the
+  uniform "≤2 decimals, trailing zeros stripped" rule (required for the canonical 210 Mbps →
+  "26.25 MB/s" and "108.25 MB/s"). The OLD `LiveConnectionStats.rateText` instead uses fixed
+  `%.1f` for KB/s and above (e.g. `340.0 KB/s`, `1000.0 KB/s`, `1.0 MB/s`) and whole B/s. These
+  genuinely conflict on whole KB/s+ values (`340 KB/s` vs `340.0 KB/s`), which the existing tests
+  assert. Per the hard rule I PORTED/KEPT the OLD rule for the default bytes path: `rateText(_:)`
+  is unchanged, and `downloadText/uploadText` (default `.bytesPerSecond`) still route through it.
+  Only the NON-default (converted-to-bits) display of throughput uses `DataRate`. Net effect: the
+  default bytes display keeps `%.1f`; a link/Tx rate CONVERTED to bytes uses `DataRate`'s 2-decimal
+  form (this asymmetry is only observable across different rows and is required to satisfy both
+  the regression net and the canonical `26.25 MB/s` example).
+- **Bits family (no default-output change).** `ConnectionDetails.linkSpeedText(_:)` (native bits,
+  used by the default interface Link-speed row and default Tx-rate row) is kept BYTE-FOR-BYTE: the
+  unit-aware `linkSpeedText(_:in:)` returns the OLD formatter verbatim for `.bitsPerSecond` and only
+  routes through `DataRate` for `.bytesPerSecond`. This avoids a latent refinement (OLD rounds sub-
+  1000 Mbps to a whole number, e.g. `866.7 → "867 Mbps"`, whereas `DataRate` would keep `"866.7
+  Mbps"`), so every default bits output is unchanged for all inputs, not just the tested ones.
+- **API shape.** Verified empirically (swiftc) that a computed `var` and a same-named method with
+  arguments coexist in Swift and disambiguate by call syntax, so `var interfaceRows` /
+  `var downloadText` / `var uploadText` / `var txRateText` remain as native-unit aliases delegating
+  to the new `interfaceRows(rateUnit:)` / `downloadText(in:)` / `uploadText(in:)` / `txRateText(in:)`
+  methods. All existing property call sites (views, previews, tests) compiled unchanged — the
+  plan's "default arguments preserve call sites" claim held.
+- **Test count:** baseline 231 → 262 test cases (+31 new), 0 failures, `** TEST SUCCEEDED **`.
+
+### Settings model (Task 3)
+
+- **AppStorage fallback confirmed empirically.** Stored `"garbage-not-a-unit"` under the
+  `interfaceRateUnit` key, then read `Settings().interfaceRateUnit` → returned `.bitsPerSecond`
+  (the property default). So an unknown/stale stored raw value falls back to the default, as the
+  Edge Cases section predicted. (Verified with a throwaway test that was then removed.)
+- **RateUnit raw/id coverage placement.** The plan listed "RateUnit raw values and id" under
+  `SettingsTests`; those assertions already live in `RateUnitTests` (in `DataRateTests.swift`,
+  Task 1), so I did not duplicate them in `SettingsTests` — only the three preference-default tests
+  were added there.
+
+### Settings page (Task 4)
+
+- **SF Symbol — used the fallback `speedometer`.** Checked the system CoreGlyphs metadata
+  (`/System/Library/CoreServices/CoreGlyphs.bundle/.../name_availability.plist`):
+  `gauge.with.dots.needle.67percent` → release **2023** (SF Symbols 5 / macOS 14+), so it is NOT
+  available at the macOS 13.0 deployment floor. `speedometer` → release 2019 (macOS 10.15+), always
+  available. Icon for `.connectionDetails` is therefore `"speedometer"` (the plan's designated
+  fallback), and `SettingsViewModelTests` asserts that value.
+- **Page order / colors.** `SettingsPage` enum order is `menubar, visuals, connectionDetails,
+  notifications, about` (inserted after `.visuals` per Design). Color `.orange`, distinct from the
+  existing red/blue/green/gray.
+- **View pattern.** `ConnectionDetailsSettingsView` mirrors `VisualsView`/`NotificationView`
+  (`@ObservedObject settings`, `Form { Section }`, `.formStyle(.grouped)`, `PickerView` with
+  `$settings.<unit>` bindings, `#Preview` with `Settings()`). Pickers iterate `RateUnit.allCases`
+  using `displayName`. Not render-tested via live preview (Xcode MCP requires a running Xcode);
+  verified by successful compile + green suite instead.
+
+### Final verification (Task 6)
+
+- **swiftlint:** `Found 0 violations, 0 serious in 38 files` for the project scope
+  (`.swiftlint.yml` sets `included: QuickNetStats`, so test files are intentionally out of scope —
+  the baseline "0 violations" has always meant the app source only).
+  - Linting the modified test files directly surfaces 8 `trailing_comma` *warnings* (not serious)
+    in `arguments:` arrays. These are the pre-existing convention across every test file in the
+    repo (e.g. the original `SettingsViewModelTests`/`SettingsTests` arrays already trail commas);
+    left unchanged so the new `DataRateTests` stays consistent with its siblings.
+- **Full suite:** 231 baseline → **268 test cases**, **0 failures**, `** TEST SUCCEEDED **`.
+- **Default-unit outputs byte-identical (verified):** every pre-existing regression assertion
+  passed unchanged — `rateTextBoundaries` (999 B/s, 1.0 KB/s, 1000.0 KB/s, 1.0 MB/s, 1.5 GB/s),
+  `throughputText` (1.2 MB/s, 340.0 KB/s), `nativeComputedPropertiesUnchanged` (210 → 210 Mbps),
+  `linkSpeedMbps`/`linkSpeedOneGbps`/`linkSpeedFractionalGbps` (866 Mbps / 1 Gbps / 2.5 Gbps),
+  `rfText` (866 Mbps), and the mock link-speed rows.
+- **Design cross-check:** all Design behaviors implemented — `DataRate`/`RateUnit`, three
+  `@AppStorage` prefs (native defaults), `interfaceRows(rateUnit:)` +
+  `downloadText/uploadText/txRateText(in:)` with native-unit delegating aliases, the
+  `connectionDetails` settings page + `ConnectionDetailsSettingsView`, and the dropdown wiring
+  (`interfaceRateUnit`→Link speed, `liveRateUnit`→Download/Upload, `wifiRateUnit`→Tx rate). No
+  behavior omitted.
+
+### Files created / modified
+
+- **Created:** `QuickNetStats/Models/DataRate.swift`,
+  `QuickNetStats/Views/SettingsView/ConnectionDetailsSettingsView.swift`,
+  `QuickNetStatsTests/DataRateTests.swift`.
+- **Modified (source):** `Models/ConnectionDetails.swift`, `Models/LiveConnectionStats.swift`,
+  `Models/Settings.swift`, `Views/SettingsView/SettingsViewModel.swift`,
+  `Views/SettingsView/SettingsView.swift`, `Views/Camponents/LiveStatsSectionView.swift`,
+  `Views/NetStatsView/ConnectionDetailsView.swift`.
+- **Modified (tests):** `ConnectionDetailsTests.swift`, `LiveConnectionStatsTests.swift`,
+  `SettingsTests.swift`, `SettingsViewModelTests.swift`.
+- `project.pbxproj` untouched (filesystem-synchronized groups picked up the new files).

--- a/context/planning/expand-connection-details-coverage.md
+++ b/context/planning/expand-connection-details-coverage.md
@@ -1,0 +1,359 @@
+# Plan: Expand Connection Details Coverage
+
+> **Date**: 2026-07-06
+> **Scope**: Surface the remaining information obtainable from the APIs the app already uses —
+> proxies, IPv6 router, IPv4 config method, DHCP server/lease start, computer name, broadcast
+> address, Ethernet media, error/drop/packet counters, Wi-Fi tx power + interface mode, and
+> NWPath capability flags + other available interfaces. Everything except reverse DNS (excluded
+> by decision).
+> **Prerequisite**: The Connection Details dropdown
+> (`context/planning/add-connection-details-dropdown.md`), shipped in 3.0.0 betas.
+
+---
+
+## Context
+
+An API-coverage audit found that the four sources the dropdown already taps (SCDynamicStore,
+getifaddrs/sysctl, CoreWLAN, NWPath) expose substantially more than we present. All items below
+are sandbox-safe, prompt-free, and macOS-13-safe. SSID/BSSID remain out of scope
+(location-gated); reverse DNS of the public IP was considered and excluded.
+
+The "maximal inclusion" principle from the parent plan still governs: prefer adding a field;
+nil values omit their row; empty groups vanish.
+
+---
+
+## Overview
+
+```
+ConnectionDetailsManager.fetchDetails()
+ ├─ SystemConfigReader   +proxies +ipv6Router +ipv4ConfigMethod +dhcpServer +leaseStart +computerName
+ ├─ InterfaceReader      +broadcast +mediaDescription +packet/error/drop counters (live)
+ ├─ WifiReader           +txPowerMw +interfaceMode
+ ├─ PathReader (NEW)     supportsIPv4/IPv6/DNS + other available interfaces   (one-shot NWPathMonitor)
+ └─ URLSession           (unchanged)
+
+Dropdown groups after this change:
+  Interface   : Name, MAC, MTU, Link speed, +Media (Ethernet), +Supports, +Also available
+  Addressing  : Router, +Router (IPv6), Subnet mask, +Broadcast, IPv6, Public IPv6,
+                +IPv4 config, Hostname, +Computer name
+  DNS & DHCP  : DNS servers, Search domains, +DHCP server, +Lease started, Lease expires
+  Proxy (NEW) : +HTTP, +HTTPS, +SOCKS        (group renders only when at least one is active)
+  Wi-Fi       : Channel, PHY mode, Generation, +Mode, +Tx power, Security, Country code
+  Live        : Download, Upload, +Packets ↓, +Packets ↑, +Errors, +Drops, RSSI, Noise, SNR, Tx rate
+```
+
+---
+
+## Design
+
+### `SystemConfigSnapshot` / `SystemConfigReader` additions
+
+- `proxies: ProxySnapshot` from `SCDynamicStoreCopyProxies(store)`: for each of HTTP/HTTPS/SOCKS,
+  when the corresponding `*Enable` key is 1, capture `"host:port"` (`kSCPropNetProxiesHTTPProxy` +
+  `...HTTPPort`, etc.). Struct with three `String?` fields.
+- `ipv6Router: String?` — `State:/Network/Global/IPv6 → Router` (next to the IPv4 key we read).
+- `ipv4ConfigMethod: String?` — per-primary-service `ConfigMethod` ("DHCP", "Manual",
+  "LinkLocal"…). Try `Setup:/Network/Service/<id>/IPv4` first, fall back to
+  `State:/Network/Service/<id>/IPv4`; record which domain worked in the Implementation Notes.
+- `dhcpServer: String?` — DHCP option 54 (4-byte IPv4) from the `SCDynamicStoreCopyDHCPInfo`
+  blob we already parse for the lease.
+- `dhcpLeaseStart: Date?` — `DHCPInfoGetLeaseStartTime` (already read internally to compute
+  expiry; now surfaced).
+- `computerName: String?` — `SCDynamicStoreCopyComputerName(store, nil)`.
+
+### `InterfaceSnapshot` / `InterfaceReader` additions
+
+- `broadcastAddress: String?` — from the `AF_INET` entry's `ifa_dstaddr` (on Darwin this union
+  member holds the broadcast address for `IFF_BROADCAST` interfaces; guard the flag and nil).
+- `mediaDescription: String?` — `ioctl(SIOCGIFMEDIA)` on a throwaway `socket(AF_INET, SOCK_DGRAM, 0)`
+  with `ifmediareq`; map common `ifm_active` subtypes (10baseT/UTP, 100baseTX, 1000baseT,
+  2500baseT, 5000baseT, 10GbaseT) plus full/half duplex from the option bits →
+  e.g. "1000baseT full-duplex". Unknown subtype or non-Ethernet media → nil. Only meaningful for
+  wired interfaces; Wi-Fi typically reports none of these subtypes and degrades to nil naturally.
+- Extended counters from the **same** `if_msghdr2.ifm_data` (`if_data64`) we already decode:
+  `rxPackets`, `txPackets` (`ifi_ipackets/opackets`), `inErrors`, `outErrors`
+  (`ifi_ierrors/oerrors`), `drops` (`ifi_iqdrops`) — all `UInt64?`, same bounds-checked walk.
+
+### `WifiSnapshot` / `WifiReader` additions
+
+- `txPowerMw: Int?` — `transmitPower()`; `<= 0` → nil.
+- `interfaceMode: String?` — `interfaceMode()` mapped by rawValue (1 → "Station", 2 → "IBSS",
+  3 → "Host AP"; 0/unknown → nil), consistent with the existing rawValue-mapping style.
+- `powerOn()`/`serviceActive()` deliberately **not** surfaced: whenever the Wi-Fi group renders
+  at all (Wi-Fi is the primary interface), they are constant-true — noise by construction.
+
+### `PathReader` (new, `QuickNetStats/Managers/PathReader.swift`)
+
+The dropdown's manager has no access to `NetworkStatsManager`'s NWPath, and coupling them would
+break the self-contained reader architecture. Instead: a fourth protocol-seamed reader.
+
+```swift
+struct PathSnapshot: Equatable {
+    var supportsIPv4: Bool?
+    var supportsIPv6: Bool?
+    var supportsDNS: Bool?
+    /// Other usable interfaces beside the primary, e.g. ["Ethernet (en1)"].
+    var otherInterfaces: [String] = []
+}
+protocol PathReading { func snapshot(excluding primaryBSDName: String?) async -> PathSnapshot }
+struct PathReader: PathReading { ... }
+```
+
+Implementation: one-shot `NWPathMonitor` — start on a utility queue, `await` the first
+`pathUpdateHandler` callback (delivered immediately on start) via a checked continuation with a
+`resumed` guard (the handler can fire more than once), then `cancel()`. Timeout guard (~2 s race
+via `Task`) returning an empty snapshot so a pathological monitor can never hang `fetchDetails`.
+`otherInterfaces` = `path.availableInterfaces` minus the primary BSD name, formatted
+"TypeLabel (bsdName)" with the existing interface-type naming ("Wi-Fi", "Ethernet", "Cellular",
+"Loopback" excluded entirely, other → "Other").
+
+### Model changes (`ConnectionDetails.swift`, `LiveConnectionStats.swift`)
+
+- `Interface`: `+ mediaDescription: String?`, `+ supports: String?` (pre-formatted
+  "IPv4 · IPv6 · DNS" — built by the manager from PathSnapshot; nil when the path reader returned
+  all-nil), `+ otherInterfaces: [String]`. New rows: "Media", "Supports", "Also available"
+  (comma-joined), appended after "Link speed" in that order.
+- `Addressing`: `+ ipv6Router`, `+ broadcastAddress`, `+ ipv4ConfigMethod`, `+ computerName`.
+  Row order per the Overview diagram ("Router (IPv6)" directly after "Router", "Broadcast" after
+  "Subnet mask", "IPv4 config" after "Public IPv6", "Computer name" last).
+- `DnsDhcp`: `+ dhcpServer: String?`, `+ dhcpLeaseStart: Date?`. Rows "DHCP server" and
+  "Lease started" before "Lease expires"; same date formatting as expiry.
+- New `Proxy` struct: `httpProxy`, `httpsProxy`, `socksProxy: String?` + `proxyRows` ("HTTP",
+  "HTTPS", "SOCKS"); all-nil → empty rows → the group never renders (existing convention).
+- `Wifi`: `+ mode: String?`, `+ txPowerMw: Int?`. Rows "Mode" (after "Generation") and
+  "Tx power" ("100 mW", after "Mode").
+- `LiveConnectionStats`: `+ downloadPacketsPerSec`, `+ uploadPacketsPerSec`, `+ errorsPerSec`
+  (in+out combined), `+ dropsPerSec` — all `Double?` with a shared integer-rate formatter
+  ("1,234/s" → keep it simple: no thousands separator, "1234/s"; sub-1 rates round to nearest
+  integer). Mocks updated.
+- All mocks (`mockWifi`, `mockEthernet`, `mockVPN`, live mocks) gain representative values;
+  `mockVPN` keeps most new fields nil to exercise omission.
+
+### Manager changes (`ConnectionDetailsManager.swift`)
+
+- Init gains `pathReader: PathReading = PathReader()`.
+- `fetchDetails()`: `async let` the path snapshot alongside the public-IPv6 fetch; assemble the
+  new model fields (including the "supports" string builder — only listed protocols whose flag
+  is `true`; all-false → "None"; all-nil → nil).
+- `tick()`: `ByteSample` grows into a `CounterSample` (bytes, packets, errors, drops, timestamp);
+  per-second rates via the existing `bytesPerSecond` helper (rename NOT required — reuse as-is
+  for each counter pair). First-tick semantics unchanged (rates nil until second sample).
+
+### Views
+
+- `ConnectionDetailsView`: insert `DetailGroupView(title: "Proxy", rows: details.proxyRows)`
+  between "DNS & DHCP" and "Wi-Fi" (with matching `Divider` handling).
+- `LiveStatsSectionView`: four new rows — "Packets ↓", "Packets ↑", "Errors", "Drops" — after
+  Upload, before the RF rows; same idle-grayed "—" convention. Packets/errors/drops rows are
+  interface-agnostic (always shown, like Download/Upload).
+- `DetailGroupView` unchanged (row-driven).
+
+### Testing (Swift Testing, TDD)
+
+- `ConnectionDetailsTests`: row building for every new field (presence, label, value, order,
+  omission on nil), proxy-group emptiness, supports-string composition (all/partial/none/nil),
+  otherInterfaces join, media row.
+- `LiveConnectionStatsTests`: new rate formatters and mocks.
+- `ConnectionDetailsManagerTests`: `MockPathReader`; assembly of supports/otherInterfaces;
+  extended live tick — packets/errors/drops deltas from mutating stubs, first-tick nil, reuse of
+  counter-reset guard.
+- `ConnectionReadersTests`: smoke — proxies read doesn't crash and returns a struct;
+  `PathReader.snapshot(excluding:)` returns within the timeout on a real monitor (lenient
+  asserts); `mediaDescription` for `lo0` is nil; extended counters non-nil for an active `en*`
+  interface when present.
+
+---
+
+## Edge Cases & Constraints
+
+- **VPN primary**: proxies may point at the VPN; config method may be absent — all rows degrade
+  to omitted. `otherInterfaces` will list the physical interfaces — correct and useful.
+- **PathReader hang-proofing**: the one-shot monitor races a ~2 s timeout and returns an empty
+  snapshot on loss; `fetchDetails` must never block on it indefinitely.
+- **SIOCGIFMEDIA on non-Ethernet**: returns unmapped/none subtypes → nil → row omitted; never an
+  error surfaced to UI.
+- **Counter deltas**: same negative-delta (reset) and zero-elapsed guards as byte throughput;
+  errors/drops usually 0/s — that is a valid, displayed value while live.
+- **Proxy ports**: missing port with enabled proxy → show host alone rather than omitting.
+- **macOS 13 floor**: all APIs used (SCDynamicStore keys, `SCDynamicStoreCopyProxies`, if_data64
+  fields, SIOCGIFMEDIA, CWInterface.transmitPower/interfaceMode, NWPathMonitor) are ≤ macOS 13.
+  No new entitlements; no location-gated calls (`ssid()`/`bssid()` remain forbidden).
+- **Out of scope**: reverse DNS of the public IP (excluded by decision), SSID/BSSID, radio
+  power/service state rows (constant-true when visible), gateway list from NWPath (redundant
+  with SCDynamicStore routers).
+
+---
+
+## Implementation Plan
+
+> **For agentic workers:** execute task-by-task with strict TDD (failing tests → run → implement
+> → green). Check each box immediately on step completion. Invoke
+> `swift-testing-expert:swift-testing-expert` before test work and
+> `swiftui-expert:swiftui-expert-skill` before view work. Fill "Implementation Notes" with real
+> observations only. **Never `git add`/`commit`/`push`.** Do not edit `project.pbxproj`.
+> Build/test: `caffeinate -dims env DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer xcodebuild test -project QuickNetStats.xcodeproj -scheme QuickNetStats -destination 'platform=macOS'`
+> (plain `xcodebuild` fails; the Mac sleeps mid-run without caffeinate). Baseline: 188/188 green,
+> swiftlint 0. SourceKit editor diagnostics are stale-indexer noise.
+
+### Task 1: Model extensions — `ConnectionDetails`
+
+- [x] **Step 1**: Write failing tests: new rows (Media, Supports, Also available, Router (IPv6),
+  Broadcast, IPv4 config, Computer name, DHCP server, Lease started, Mode, Tx power), their
+  labels/order/omission-on-nil, `proxyRows` (three rows, partial, empty), updated mocks.
+- [x] **Step 2**: Test run → expected compile failures.
+- [x] **Step 3**: Implement fields, rows, `Proxy` struct, mock updates.
+- [x] **Step 4**: Full suite green.
+
+### Task 2: Model extensions — `LiveConnectionStats`
+
+- [x] **Step 1**: Write failing tests: packets/errors/drops fields, integer-rate formatter
+  ("1234/s"), text properties, mock updates.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement. **Step 4**: Green.
+
+### Task 3: `SystemConfigReader` additions
+
+- [x] **Step 1**: Extend `SystemConfigSnapshot` (proxies, ipv6Router, ipv4ConfigMethod,
+  dhcpServer, dhcpLeaseStart, computerName) + lenient smoke tests (no crash; types sane;
+  proxies struct returned).
+- [x] **Step 2**: Run → fail. **Step 3**: Implement per Design (record the ConfigMethod domain
+  that actually worked). **Step 4**: Green; eyeball one real snapshot via test print, then
+  remove the print.
+
+### Task 4: `InterfaceReader` additions
+
+- [x] **Step 1**: Extend `InterfaceSnapshot` (broadcastAddress, mediaDescription, rxPackets,
+  txPackets, inErrors, outErrors, drops); failing tests for any pure helpers (media subtype
+  mapping table) + smoke tests (`lo0` media nil; active `en*` counters non-nil when present).
+- [x] **Step 2**: Run → fail. **Step 3**: Implement (SIOCGIFMEDIA ioctl with closed socket
+  `defer`-closed; extend the existing bounds-checked `if_msghdr2` decode). **Step 4**: Green.
+
+### Task 5: `WifiReader` additions
+
+- [x] **Step 1**: Extend `WifiSnapshot` (txPowerMw, interfaceMode) + smoke tests.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement (rawValue mapping; ≤0 power → nil).
+  **Step 4**: Green.
+
+### Task 6: `PathReader` (new)
+
+- [x] **Step 1**: Failing tests: protocol + `MockPathReader` usable; real `PathReader` smoke —
+  returns within timeout, `otherInterfaces` excludes the primary and loopback.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement one-shot monitor with continuation guard +
+  timeout race. **Step 4**: Green.
+
+### Task 7: Manager assembly + live tick
+
+- [x] **Step 1**: Failing tests with mock readers: supports-string builder (all/partial/none/nil),
+  otherInterfaces passthrough, proxy passthrough, new fetch assembly; live tick publishes
+  packets/errors/drops rates from second tick (mutating stub), first tick nil, reset guard.
+- [x] **Step 2**: Run → fail. **Step 3**: Implement (`pathReader` seam, `CounterSample`,
+  assembly). **Step 4**: Green.
+
+### Task 8: Views
+
+- [x] **Step 1**: Invoke swiftui-expert. Add Proxy group to `ConnectionDetailsView`; add the four
+  Live rows to `LiveStatsSectionView`; update previews (richer mocks flow automatically).
+- [x] **Step 2**: Build succeeds; full suite green.
+
+### Task 9: Final verification
+
+- [x] **Step 1**: swiftlint → 0 violations.
+- [x] **Step 2**: Full suite green; re-read the Design section and confirm every field/row is
+  implemented or its absence noted; record deviations below.
+
+---
+
+## Implementation Notes (deviations & observations)
+
+### Task 3 — SystemConfigReader (real values observed via throwaway diagnostic, now removed)
+
+- **ConfigMethod domain**: the `Setup:` domain served it (`Setup ConfigMethod=DHCP`,
+  `State ConfigMethod=nil`). The Setup-first / State-fallback order in `ipv4ConfigMethod` is
+  correct on this machine.
+- Real snapshot values on the dev Mac:
+  - `proxies=ProxySnapshot(http: nil, https: nil, socks: nil)` (no proxies active — struct still
+    returns, all rows omitted; proxy formatting therefore not exercised against a live proxy).
+  - `ipv6Router=fe80::e2d3:62ff:fe78:5ba4` (a link-local IPv6 router — surfaced verbatim as
+    designed).
+  - `ipv4ConfigMethod=DHCP`
+  - `dhcpServer=10.0.0.1` (DHCP option 54 decoded to a dotted quad — 4-byte parse works).
+  - `dhcpLeaseStart=2026-06-29 16:48:06 +0000` (`DHCPInfoGetLeaseStartTime` bridges to `Date`).
+  - `computerName=Eurydice`
+- No deviation from the design; all new fields populated as specified.
+
+### Task 4 — InterfaceReader
+
+- `ifmediareq` is declared in `<net/if.h>` (not `<net/if_media.h>`) under `#pragma pack(4)`, so
+  its C `sizeof` is 44. `SIOCGIFMEDIA` (`_IOWR('i', 56, ifmediareq)`) is a function-like macro and
+  is **not** imported into Swift, so `siocgifmedia` is computed from `<sys/ioccom.h>` using
+  `MemoryLayout<ifmediareq>.stride`; it evaluates to the canonical `0xc02c6938` (verified against
+  an independent computation).
+- Verified via a throwaway diagnostic (now removed): the ioctl **succeeds** (returns 0) and
+  populates `ifm_active` even when the mapping yields nil — `en0` (down Ethernet) returned
+  `ifm_active=34` = IFM_ETHER + a non-link subtype, `en1` (Wi-Fi) returned `ifm_active=128` =
+  IFM_IEEE80211. Both correctly map to nil (not Ethernet-with-a-speed-subtype). No active wired
+  link was present on the dev Mac, so a real "1000baseT full-duplex" string was not observed live —
+  that path is covered by the pure-helper unit tests.
+- Real counter/broadcast values observed: `en1` (active Wi-Fi) `broadcast=10.0.0.255`,
+  `rxBytes≈3.15 GB`, `rxPackets≈20.8 M`, `txPackets≈8.0 M`, `inErrors/outErrors/drops=0`; `lo0`
+  counters present, media nil. `ifi_iqdrops` used for `drops`.
+- `ipv6String(from:)` was generalized/renamed to `numericHost(from:)` (used by both the IPv6 and
+  the new broadcast paths) — a rename, not a behavior change.
+
+### Task 5 — WifiReader
+
+- `interfaceMode` mapped by rawValue (1→Station, 2→IBSS, 3→Host AP; 0/unknown→nil) via a new
+  internal `modeText(_:)` (made internal, not private, so it has a pure unit test — matching how
+  `InterfaceReader.mediaDescription(active:)` is tested). `transmitPower() <= 0 → nil`.
+- `powerOn()`/`serviceActive()` deliberately not surfaced, per design.
+
+### Task 6 — PathReader (new file `QuickNetStats/Managers/PathReader.swift`)
+
+- One-shot `NWPathMonitor` on a utility `DispatchQueue`, first callback awaited via a
+  `CheckedContinuation`, raced against a `Task.sleep(timeout)` inside a `withTaskGroup`.
+- **Bug caught during implementation**: the first draft's `onCancel` could not reach the
+  continuation, so when the timeout won the race the cancelled child task would hang and, because
+  `withTaskGroup` waits for all children, the whole call would hang. Fixed by moving the
+  continuation into a lock-guarded `ResumeGuard` that both the monitor callback and `onCancel`
+  resume through (single-resume guaranteed; a resume arriving before `attach` is stashed and
+  delivered on attach — covers cancel-before-continuation-runs). The real-monitor smoke test
+  returns in well under the timeout.
+- `otherInterfaces` excludes the primary BSD name and loopback; formatted "TypeLabel (bsdName)".
+
+### Task 7 — Manager assembly + live tick
+
+- `pathReader: PathReading = PathReader()` added as the 4th reader seam; `fetchDetails` `async let`s
+  the path snapshot alongside the public-IPv6 fetch.
+- `supportsText(_:)` builds "IPv4 · IPv6 · DNS" (true flags only; all-false → "None"; all-nil → nil).
+- `ByteSample` became `CounterSample` (bytes, packets, combined in+out errors, drops, timestamp).
+  **Design-consistent choice**: `counterSample(from:)` is all-or-nothing — it returns nil unless
+  every counter is present, since they all come from one `if_data64` read. Test fixtures/mocks were
+  extended accordingly (`fullInterface` gains packet/error/drop base values; `MockInterfaceReader`
+  grows packets alongside bytes). All rates reuse `bytesPerSecond` (reset/zero-elapsed guarded).
+
+### Task 8 — Views
+
+- **Deviation (improvement) from the plan wording**: the plan said add the Proxy group "with
+  matching Divider handling". Blindly mirroring the existing unconditional `Divider()` pattern would
+  show a stray divider for the majority (no-proxy) case, so the Proxy `Divider()` + group are gated
+  together on `!details.proxyRows.isEmpty`. Matches the design intent ("group renders only when at
+  least one is active").
+- Four interface-agnostic Live rows ("Packets ↓/↑", "Errors", "Drops") added after Upload, before
+  the RF rows; same idle-grayed "—" convention. Previews inherit the richer mocks automatically
+  (the Wi-Fi preview now shows the Proxy group from `mockWifi`).
+
+### Task 9 — Verification
+
+- `swiftlint lint`: **0 violations, 0 serious** in 36 files (PathReader.swift confirmed linted
+  separately: 0 violations).
+- Full suite: **`** TEST SUCCEEDED **`, 0 failures**. xcodebuild's console per-function count was
+  165 (the plan's "188" counts each parameterized argument separately — a different metric, per the
+  known log-counting caveat). Net new test functions across Tasks 1–7: 28.
+- Design cross-check: every field/row in the Overview and Design sections is implemented (Interface
+  Media/Supports/Also available; Addressing Router (IPv6)/Broadcast/IPv4 config/Computer name;
+  DNS & DHCP DHCP server/Lease started; Proxy HTTP/HTTPS/SOCKS; Wi-Fi Mode/Tx power; Live
+  Packets ↓/↑, Errors, Drops). Nothing from the out-of-scope list was added.
+- Not verified: a live wired Ethernet media string (no active wired link on the dev Mac — ioctl
+  path proven to succeed and map to nil; the "1000baseT full-duplex" mapping is covered only by the
+  pure-helper unit tests). Live proxy formatting against a real active proxy (none configured on the
+  dev Mac). SwiftUI previews were not visually rendered (build + full suite green only, per plan).

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,7 +48,12 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
     die "Tag '$TAG' already exists"
 fi
 
-info "Releasing $APP_NAME as $TAG"
+# Derive the version from the tag (strip leading v/V and optional dot),
+# e.g. V.3.0.0-Beta-2 -> 3.0.0-Beta-2. Same rule as UpdateManager.cleanVersion(fromTag:).
+VERSION="${TAG#[vV]}"
+VERSION="${VERSION#.}"
+
+info "Releasing $APP_NAME as $TAG (version $VERSION)"
 
 # ─── Step 1: Archive ────────────────────────────────────────────────────────
 info "Building release archive..."
@@ -57,7 +62,8 @@ xcodebuild archive \
     -scheme "$SCHEME" \
     -configuration Release \
     -archivePath "$ARCHIVE_PATH" \
-    -quiet
+    -quiet \
+    MARKETING_VERSION="$VERSION"
 
 [ -d "$ARCHIVE_PATH" ] || die "Archive failed — $ARCHIVE_PATH not found"
 green "Archive created"
@@ -115,10 +121,6 @@ if [[ "$TAG" == *[Bb]eta* ]]; then
     PRERELEASE_FLAG="--prerelease"
     info "Detected beta release"
 fi
-
-# Extract version for the title (strip v/V prefix and leading dot)
-VERSION="${TAG#[vV]}"
-VERSION="${VERSION#.}"
 
 gh release create "$TAG" "$ZIP_NAME" \
     --title "$VERSION" \


### PR DESCRIPTION
All 3.0.0 feature work: the Connection Details dropdown (interface, addressing, DNS/DHCP, proxy, Wi-Fi, live stats), opt-in SSID/BSSID via Location Services, per-section rate units, connection-change flushing, and screen-aware height capping. Soaked through Betas 1–7.